### PR TITLE
Add tag verification step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Verify tag matches VERSION file
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE_VERSION="$(tr -d '[:space:]' < VERSION)"
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match VERSION file (${FILE_VERSION})"
+            exit 1
+          fi
+
       - name: Install UV
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
@@ -64,39 +73,58 @@ jobs:
           generate_release_notes: true
           files: dist/*
 
+# Disabled until the PyPI project name is reserved and a Trusted Publisher is configured
+# for databrickslabs/impulse + release.yml + environment `pypi`. See:
+# https://pypi.org/manage/project/databricks-impulse/settings/publishing/
 #  pypi-publish:
 #    name: Publish to PyPI
 #    needs: build
-#    runs-on: ubuntu-latest
+#    runs-on:
+#      group: databrickslabs-protected-runner-group
+#      labels: linux-ubuntu-latest
 #    environment:
 #      name: pypi
-#      url: https://pypi.org/p/mda-query-engine
+#      url: https://pypi.org/p/databricks-impulse
+#    permissions:
+#      id-token: write
+#      contents: read
 #    steps:
 #      - name: Download distribution artifacts
-#        uses: actions/download-artifact@v8
+#        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
 #        with:
 #          name: dist
 #          path: dist/
 #
 #      - name: Publish to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
+#        # OIDC trusted publishing — no token needed.
+#        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 #        with:
-#          # Uses OIDC trusted publishing - no token needed
-#          # Configure at: https://pypi.org/manage/project/YOUR-PROJECT/settings/publishing/
 #          skip-existing: true
 #
+# Disabled until pypi-publish is enabled; signs the published artifacts and attaches the
+# Sigstore bundles back to the GitHub Release for offline verification.
 #  sigstore-sign:
 #    name: Sign with Sigstore
-#    needs: pypi-publish
-#    runs-on: ubuntu-latest
+#    needs: [build, pypi-publish]
+#    runs-on:
+#      group: databrickslabs-protected-runner-group
+#      labels: linux-ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: write
 #    steps:
 #      - name: Download distribution artifacts
-#        uses: actions/download-artifact@v8
+#        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
 #        with:
 #          name: dist
 #          path: dist/
 #
 #      - name: Sign with Sigstore
-#        uses: sigstore/gh-action-sigstore-python@v3.2.0
+#        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
 #        with:
-#          inputs: dist/*
+#          inputs: ./dist/*.tar.gz ./dist/*.whl
+#
+#      - name: Attach signatures to GitHub Release
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        run: gh release upload "$GITHUB_REF_NAME" dist/*.sigstore.json --clobber


### PR DESCRIPTION
This update introduces a new step in the GitHub Actions release workflow to verify that the tag matches the version specified in the VERSION file. If there is a mismatch, an error is raised, ensuring consistency between the tag and the versioning. Additionally, commented out sections related to PyPI publishing and signing have been updated (version hardening)

## Summary

<!-- Brief description of the changes -->

## Changes

- 

## Test Plan

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Documentation updated (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No new linter warnings introduced
