### PR TITLE
Refactor schema handling in solvers: Derive container_id type dynamically

### DIFF
--- a/docs/impulse/docs/data_model/gold_layer_event_normalized.md
+++ b/docs/impulse/docs/data_model/gold_layer_event_normalized.md
@@ -16,6 +16,16 @@ All gold-layer table names are prefixed with the configured
 `table_prefix: "my_report"` the histogram fact table becomes
 `my_report_histogram_fact`).
 
+:::note container_id type
+
+The `container_id` type shown in the diagrams and tables below
+(`long`/`int`) is the typical default. The gold layer inherits whatever
+`container_id` type your silver tables use (e.g. `string`) — fact and
+dimension rows are written with the source `container_id` type, not cast to a
+fixed one. See [Silver Layer Schema](silver_layer_schema.md).
+
+:::
+
 ## Entity-relationship diagram
 
 ```mermaid

--- a/docs/impulse/docs/data_model/ingestion.md
+++ b/docs/impulse/docs/data_model/ingestion.md
@@ -213,8 +213,10 @@ scoping filters without writing code, but the underlying tables must
 still follow the silver-layer relationships (EAV tag tables,
 per-`(container_id, channel_id)` channels rows, etc.) and the internal
 key names (`container_id`, `channel_id`) themselves are fixed
-constants. For different relationships or composite keys, see custom
-solvers below.
+constants. Their column *types* are not fixed, though — `container_id`
+in particular may be a `long`, `int`, or `string`; the engine adopts
+whatever type your tables use, as long as it is consistent across them.
+For different relationships or composite keys, see custom solvers below.
 
 ### Custom solvers
 

--- a/docs/impulse/docs/data_model/silver_layer_schema.md
+++ b/docs/impulse/docs/data_model/silver_layer_schema.md
@@ -22,6 +22,13 @@ overrides are applied. The framework hard-requires only a small subset of this s
 - one of the two `channels` formats below (RLE with `tstart`/`tend` or
   raw with `timestamp`).
 
+`container_id` may be any Spark type (e.g. `long`, `int`, or `string`): the
+engine derives its type from your tables at query time and carries it through
+to the gold layer, so it is **not** required to be `long`. The only constraint
+is that the type is **consistent across all silver tables**, since the engine
+joins them on `container_id`. The `long` shown throughout this page is the
+typical default, not a requirement.
+
 Any other column on `container_metrics` and `channel_metrics` is
 optional and only consulted when referenced by your config (e.g. via
 [`measurement_dimensions`](../config/configuration.md#measurement_dimensions-optional)

--- a/src/impulse_query_engine/analyze/query/solvers/delta_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/delta_solver.py
@@ -3,7 +3,6 @@ from functools import partial
 
 import pandas as pd
 import pyspark.sql.functions as F
-import pyspark.sql.types as T
 from pyspark.sql import DataFrame
 
 from impulse_query_engine.analyze.metadata.metric_expression import MetricExpression
@@ -241,7 +240,7 @@ class DeltaSolver(QuerySolver):
         mids = container_df.select(container_id_col).distinct()
 
         if len(selectors) == 0:
-            return self._empty_channel_match_df(spark)
+            return self._empty_channel_match_df(spark, db)
 
         required_tags = set()
         for selector in selectors:
@@ -364,10 +363,7 @@ class DeltaSolver(QuerySolver):
             # Calculate the tend info and prepare the data for the solving step.
             q = self.interval_encoder.prepare_channels_df(q)
 
-        schema_entries = [T.StructField(self.config.container_id_col, T.LongType())]
-        for s, dtype in zip(selections, dtypes, strict=False):
-            schema_entries.append(T.StructField(s._alias, dtype))
-        schema = T.StructType(schema_entries)
+        schema = self._build_solve_output_schema(q, selections, dtypes)
 
         solve_udf = F.pandas_udf(
             partial(DeltaSolver._solve_udf, selections=selections, col_map=col_map),

--- a/src/impulse_query_engine/analyze/query/solvers/key_value_store_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/key_value_store_solver.py
@@ -341,7 +341,7 @@ class KeyValueStoreSolver(QuerySolver):
             channel_metrics_df, self.config.channel_metrics.column_name_mapping
         )
         if len(selectors) == 0:
-            return self._empty_channel_match_df(spark)
+            return self._empty_channel_match_df(spark, db)
 
         channel_metrics_df = channel_metrics_df.where(self._build_expr(selectors))
         result = channel_metrics_df.join(
@@ -403,7 +403,7 @@ class KeyValueStoreSolver(QuerySolver):
         channel_id_col = self.config.channel_id_col
 
         if len(selectors) == 0:
-            return self._empty_channel_match_df(spark)
+            return self._empty_channel_match_df(spark, db)
 
         channel_mapping = db.channel_mapping(spark)
         channel_mapping = self._apply_column_mapping(
@@ -850,10 +850,7 @@ class KeyValueStoreSolver(QuerySolver):
             # Calculate the tend info and prepare the data for the solving step.
             q = self.interval_encoder.prepare_channels_df(q)
 
-        schema_entries = [T.StructField(self.config.container_id_col, T.LongType())]
-        for s, dtype in zip(selections, dtypes, strict=False):
-            schema_entries.append(T.StructField(s._alias, dtype))
-        schema = T.StructType(schema_entries)
+        schema = self._build_solve_output_schema(q, selections, dtypes)
         solve_udf = F.pandas_udf(
             partial(KeyValueStoreSolver._solve_udf, selections=selections, col_map=col_map),
             schema,

--- a/src/impulse_query_engine/analyze/query/solvers/query_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/query_solver.py
@@ -65,13 +65,63 @@ class QuerySolver(ABC):
                 expr = expr | filt.get_selector_expr()
         return expr
 
-    def _empty_channel_match_df(self, spark) -> DataFrame:
+    def _build_solve_output_schema(self, channels: DataFrame, selections, dtypes) -> T.StructType:
+        """Build the grouped-map UDF output schema for the ``solve`` stage.
+
+        The ``container_id`` field type is derived from *channels* (the
+        column-mapped channels DataFrame) so it matches the physical type of
+        the source table instead of being hardcoded.  Each selection
+        contributes one field, named after its ``_alias`` and typed by the
+        paired entry in *dtypes*.
+
+        Parameters
+        ----------
+        channels : pyspark.sql.DataFrame
+            The column-mapped channels DataFrame whose ``container_id`` column
+            type is authoritative for the grouped output.
+        selections : Iterable
+            Selection expressions; each contributes a result field.
+        dtypes : Iterable
+            Output Spark data types, paired positionally with *selections*.
+
+        Returns
+        -------
+        pyspark.sql.types.StructType
+            ``[container_id, <selection aliases…>]`` schema.
+        """
+        entries = [
+            T.StructField(
+                self.config.container_id_col,
+                channels.schema[self.config.container_id_col].dataType,
+            )
+        ]
+        for s, dtype in zip(selections, dtypes, strict=False):
+            entries.append(T.StructField(s._alias, dtype))
+        return T.StructType(entries)
+
+    def _empty_channel_match_df(self, spark, db: MeasurementDB) -> DataFrame:
+        """Return an empty ``(container_id, channel_id, selector_ids)`` DataFrame.
+
+        The ``container_id`` and ``channel_id`` types are derived from the
+        column-mapped ``channel_metrics`` table (the source of the real
+        channel-match rows this empty frame is union'd/joined with) so the
+        schemas stay compatible regardless of the physical id types.
+        """
+        ref = self._apply_column_mapping(
+            db.channel_metrics(spark), self.config.channel_metrics.column_name_mapping
+        )
         return spark.createDataFrame(
             [],
             schema=T.StructType(
                 [
-                    T.StructField(self.config.container_id_col, T.LongType()),
-                    T.StructField(self.config.channel_id_col, T.LongType()),
+                    T.StructField(
+                        self.config.container_id_col,
+                        ref.schema[self.config.container_id_col].dataType,
+                    ),
+                    T.StructField(
+                        self.config.channel_id_col,
+                        ref.schema[self.config.channel_id_col].dataType,
+                    ),
                     T.StructField("selector_ids", T.ArrayType(T.IntegerType())),
                 ]
             ),

--- a/tests/impulse_query_engine/unit/analyze/query/solvers/container_id_type_test.py
+++ b/tests/impulse_query_engine/unit/analyze/query/solvers/container_id_type_test.py
@@ -1,0 +1,84 @@
+# pylint: disable=missing-function-docstring
+"""``container_id`` may be any Spark type, not just ``LongType``.
+
+The solvers derive the ``container_id`` type of their grouped-map UDF output
+schema (and of the empty channel-match frame) from the source tables instead
+of hardcoding ``LongType``.  These tests reuse the existing solver fixtures and
+simply recast ``container_id`` to ``StringType`` / ``IntegerType`` before
+solving, then assert the type is preserved end-to-end.
+
+See ``QuerySolver._build_solve_output_schema`` and
+``QuerySolver._empty_channel_match_df``.
+"""
+
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+import pytest
+
+from impulse_query_engine.analyze.query.solvers.delta_solver import DeltaSolver
+from impulse_query_engine.analyze.query.solvers.key_value_store_solver import (
+    KeyValueStoreSolver,
+)
+from impulse_query_engine.measurement_db import MeasurementDB, MeasurementDBConfig
+from tests.conftest import basic_narrow_db, narrow_db, spark  # noqa: F401  (pytest fixtures)
+
+# StringType / IntegerType are the new cases; LongType locks in backward compatibility.
+_CID_TYPES = [T.StringType(), T.IntegerType(), T.LongType()]
+
+
+def _recast_container_id(db: MeasurementDB, cid_type: T.DataType) -> MeasurementDB:
+    """Clone a ``for_debug`` db, casting ``container_id`` to *cid_type* on every table."""
+    tables = {
+        name: (
+            df.withColumn("container_id", F.col("container_id").cast(cid_type))
+            if "container_id" in df.columns
+            else df
+        )
+        for name, df in db.config.debug_tables.items()
+    }
+    return MeasurementDB(MeasurementDBConfig.for_debug(tables), ws=db.ws)
+
+
+@pytest.mark.parametrize("cid_type", _CID_TYPES, ids=lambda t: t.simpleString())
+def test_delta_solve_preserves_container_id_type(spark, narrow_db, cid_type):
+    db = _recast_container_id(narrow_db, cid_type)
+    query = db.query
+    result = query.select(query.channel(seed="0").mean().alias("m")).solve(
+        spark, solver=DeltaSolver(spark)
+    )
+    assert result.schema["container_id"].dataType == cid_type
+    means = [row.m for row in result.collect()]
+    assert any(m is not None and m != 0 for m in means), means
+
+
+@pytest.mark.parametrize("cid_type", _CID_TYPES, ids=lambda t: t.simpleString())
+def test_kvs_solve_preserves_container_id_type(spark, basic_narrow_db, cid_type):
+    db = _recast_container_id(basic_narrow_db, cid_type)
+    query = db.query
+    result = query.select(
+        query.channel(channel_name="Vehicle Speed Sensor").mean().alias("m")
+    ).solve(spark, solver=KeyValueStoreSolver(spark))
+    assert result.schema["container_id"].dataType == cid_type
+    means = [row.m for row in result.collect()]
+    assert any(m is not None and m != 0 for m in means), means
+
+
+@pytest.mark.parametrize("solver_cls", [DeltaSolver, KeyValueStoreSolver])
+def test_empty_channel_match_df_derives_types(spark, basic_narrow_db, solver_cls):
+    """The empty channel-match frame derives its id type from channel_metrics."""
+    db = _recast_container_id(basic_narrow_db, T.StringType())
+    empty = solver_cls(spark)._empty_channel_match_df(spark, db)
+    assert empty.schema["container_id"].dataType == T.StringType()
+    assert "channel_id" in empty.columns
+    assert empty.count() == 0
+
+
+def test_kvs_solve_empty_result_preserves_type(spark, basic_narrow_db):
+    """KeyValueStoreSolver's ``container_count == 0`` path keeps the string type."""
+    db = _recast_container_id(basic_narrow_db, T.StringType())
+    query = db.query
+    result = query.select(
+        query.channel(channel_name="Nonexistent Channel").mean().alias("m")
+    ).solve(spark, solver=KeyValueStoreSolver(spark))
+    assert result.schema["container_id"].dataType == T.StringType()
+    assert result.count() == 0

--- a/tests/impulse_reporting/integration/string_container_id_report_test.py
+++ b/tests/impulse_reporting/integration/string_container_id_report_test.py
@@ -1,0 +1,109 @@
+# pylint: disable=missing-function-docstring
+"""End-to-end reporting test with a STRING-typed ``container_id``.
+
+The query engine derives the ``container_id`` type from the source tables
+instead of hardcoding ``LongType``.  The reporting persist path is
+projection-based (``select(FACT_SCHEMA.fieldNames())``) and writes with
+``overwriteSchema=True``, so a string ``container_id`` should flow unchanged
+to the gold layer.  This reuses the basic silver tables, recasting
+``container_id`` to string, then runs a full report and asserts the gold fact
+and measurement-dimension tables keep the ``StringType`` ``container_id``.
+"""
+
+from unittest.mock import create_autospec
+
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+import pytest
+from databricks.sdk import WorkspaceClient
+
+from impulse_reporting.aggregations.histogram import HistogramDuration
+from impulse_reporting.config.config_parser import (
+    Comparator,
+    ContainerFilters,
+    ImpulseConfig,
+    MetricFilter,
+    QueryEngine,
+    Solvers,
+    Source,
+    UnitySink,
+)
+from impulse_reporting.core.page import Page
+from impulse_reporting.core.report import Report
+from tests.conftest import setup_basic_db, spark  # noqa: F401  (pytest fixtures)
+
+_STRING_CID_SCHEMA = "spark_catalog.silver_string_cid"
+
+
+@pytest.fixture
+def setup_string_cid_db(spark, setup_basic_db):  # noqa: F811
+    """Silver tables cloned from the basic db with ``container_id`` cast to string."""
+    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {_STRING_CID_SCHEMA}")
+    for table in ("container_metrics", "channel_metrics", "channels"):
+        spark.read.table(f"spark_catalog.silver.{table}").withColumn(
+            "container_id", F.col("container_id").cast("string")
+        ).write.format("delta").mode("overwrite").saveAsTable(f"{_STRING_CID_SCHEMA}.{table}")
+    yield
+    spark.sql(f"DROP SCHEMA IF EXISTS {_STRING_CID_SCHEMA} CASCADE")
+
+
+def test_persist_report_string_container_id(spark, setup_string_cid_db):
+    config = dict(
+        ImpulseConfig(
+            source=Source(
+                container_metrics_table=f"{_STRING_CID_SCHEMA}.container_metrics",
+                channel_metrics_table=f"{_STRING_CID_SCHEMA}.channel_metrics",
+                channels_uri=f"{_STRING_CID_SCHEMA}.channels",
+            ),
+            unity_sink=UnitySink(
+                catalog="spark_catalog", schema="gold", table_prefix="evaluation"
+            ),
+            container_filters=ContainerFilters(
+                metric_filters=[
+                    [
+                        MetricFilter(
+                            column_name="vehicle_key", comparator=Comparator.EQ, value="Seat_Leon"
+                        )
+                    ]
+                ]
+            ),
+            query_engine=QueryEngine(solver=Solvers.KEY_VALUE_STORE_SOLVER),
+            # Include container_id so it lands in the measurement-dimension table too.
+            measurement_dimensions=["container_id", "uut_id", "file_name", "file_path"],
+        )
+    )
+
+    report = Report(
+        name="string_cid_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=config,
+    )
+    query = report.get_db().query
+    page = Page(page_number=1)
+    report.add_page(page)
+    page.add_aggregation(
+        HistogramDuration(
+            "rpm_hist",
+            base_expr=query.channel(channel_name="Engine RPM"),
+            bins=[float(i) for i in range(0, 8000, 250)],
+        )
+    )
+
+    report.determine_report()
+    report.persist_results()
+    # Second persist merges string-keyed rows into the existing gold tables (Delta MERGE).
+    report.persist_results()
+
+    histogram_fact = spark.read.table("spark_catalog.gold.evaluation_histogram_fact")
+    measurement_dimension = spark.read.table("spark_catalog.gold.evaluation_measurement_dimension")
+
+    # The key assertion: container_id keeps StringType all the way to gold — it is NOT
+    # coerced to the IntegerType declared in fact_schema.py.
+    assert histogram_fact.schema["container_id"].dataType == T.StringType()
+    assert measurement_dimension.schema["container_id"].dataType == T.StringType()
+
+    # The fact table is actually populated with real, non-zero histogram values.
+    assert histogram_fact.count() > 0, "histogram fact table is empty"
+    total_hist_value = histogram_fact.agg(F.sum("hist_value")).first()[0]
+    assert total_hist_value is not None and total_hist_value > 0, total_hist_value


### PR DESCRIPTION
## Summary
- Updated DeltaSolver and KeyValueStoreSolver to use a new method for building the output schema, ensuring the container_id type is derived from the channels DataFrame instead of being hardcoded.
- Modified the _empty_channel_match_df method to accept a database parameter, enhancing flexibility.
- Added unit and integration tests to verify that the container_id type is preserved across different scenarios, including when using STRING and INTEGER types.

## Changes

- 

## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Documentation updated (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [ ] Self-review completed
- [x] No new linter warnings introduced
