### PR TITLE
Skip JFrog OIDC steps on fork PRs in CI

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -17,8 +17,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  not-a-fork:
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+    steps:
+      - run: echo "Not a fork PR, proceeding"
+
   lint:
     name: Lint and format check
+    needs: not-a-fork
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest


### PR DESCRIPTION
Add a not-a-fork gate job (as databrickslabs/dqx does) and make lint depend on it; on a fork PR not-a-fork is skipped, cascading to lint and test.