### PR TITLE
Refactor data model documentation for clarity and conciseness

### DIFF
--- a/docs/impulse/docs/data_model/index.md
+++ b/docs/impulse/docs/data_model/index.md
@@ -4,27 +4,18 @@ title: Data Model
 
 # Data Model
 
-:::caution Prerequisite
+:::tip Start with three tables
 
-The schema described on this page is the full silver-layer shape that
-Impulse's [**`DefaultSolver`**](../references/query_engine.md) recognises.
-**Landing your data in this shape during ingest is the simplest and most
-maintainable path** — see the [Ingestion guide](ingestion.md).
+[`DefaultSolver`](../references/query_engine.md) needs **only three tables**:
+`container_metrics`, `channel_metrics`, and `channels`. The tag tables
+(`container_tags`, `channel_tags`) and the `channel_mapping` / `unit_conversion`
+tables are **fully optional** add-ons, used only when configured — see the
+[Query Engine table requirements](../references/query_engine.md#table-requirements).
 
-`DefaultSolver` also runs on a **subset** of this model: only
-`container_metrics`, `channel_metrics`, and `channels` are required.
-`container_tags` (EAV container filtering), `channel_tags` (EAV channel
-selection), `channel_mapping` (aliases), and `unit_conversion` are optional
-add-ons that the solver uses when configured. See the
-[Query Engine](../references/query_engine.md#table-requirements) page for
-the table-requirements matrix.
-
-Advanced deployments with existing data layouts they cannot or do not want
-to reshape can adapt further by passing a `SolverConfig` to remap column
-names, or by implementing a custom solver for fundamentally different
-physical layouts. The ingestion guide's
-[last section](ingestion.md#adapting-to-existing-data-layouts) covers the
-tradeoffs.
+The rest of this page documents the full shape. Landing your data in it during
+ingest is the simplest path (see the [Ingestion guide](ingestion.md)); if you
+can't reshape, a [`SolverConfig`](ingestion.md#adapting-to-existing-data-layouts)
+can remap column names, or you can implement a custom solver.
 
 :::
 
@@ -40,18 +31,17 @@ All layers are stored as Delta tables in Unity Catalog, which makes them easy to
 
 ## Silver Layer (Input)
 
-The Silver layer uses a **tag-based model** where metadata is separated from time-series data. Three tables are required (`container_metrics`, `channel_metrics`, `channels`); two optional tag tables (`container_tags`, `channel_tags`) carry contextual metadata used by the channel selection API.
+**Only three tables are required** — `container_metrics`, `channel_metrics`, and `channels`. The two tag tables (`container_tags`, `channel_tags`) are **fully optional**: add them only when you want tag-based container filtering or EAV channel selection.
 
-| Table               | Purpose                                                                                |
-|---------------------|----------------------------------------------------------------------------------------|
-| `container_metrics` | One row per measurement container with timestamps, duration, and channel count.        |
-| `container_tags`    | Key-value metadata tags for containers (e.g. `vehicle_key`, `project_id`).             |
-| `channel_metrics`   | Pre-computed statistics per channel (min, max, mean, percentiles, sample count).        |
-| `channel_tags`      | Key-value metadata tags per channel (e.g. `channel_name`, `brand`, `model`).           |
-| `channels`          | Time-series sample data, either as raw `(timestamp, value)` samples or as run-length-encoded intervals `[tstart, tend)`. |
+| Table               | Required? | Purpose                                                                                |
+|---------------------|-----------|----------------------------------------------------------------------------------------|
+| `container_metrics` | **Yes**   | One row per measurement container with timestamps, duration, and channel count.        |
+| `channel_metrics`   | **Yes**   | Pre-computed statistics per channel (min, max, mean, percentiles, sample count). Also carries channel-selection columns (e.g. `channel_name`) in the wide model. |
+| `channels`          | **Yes**   | Time-series sample data, either as raw `(timestamp, value)` samples or as run-length-encoded intervals `[tstart, tend)`. |
+| `container_tags`    | Optional  | Key-value metadata tags for containers (e.g. `vehicle_key`, `project_id`).             |
+| `channel_tags`      | Optional  | Key-value metadata tags per channel (e.g. `channel_name`, `brand`, `model`).           |
 
-Channels are selected by querying `channel_tags` (e.g. `channel_name = "Engine RPM"`) rather than by fixed column names.
-This allows the same schema to support arbitrary signal sets across different projects.
+Channels are selected either from an EAV `channel_tags` table (e.g. `channel_name = "Engine RPM"`) or directly from columns on `channel_metrics` — in both cases by signal metadata rather than fixed column positions, so the same schema supports arbitrary signal sets across projects.
 
 See the [Silver Layer ER Diagram](silver_layer_schema.md) for table relationships.
 For background on the design, see the [Databricks blog post on revolutionizing car measurement data storage and analysis](https://www.databricks.com/blog/revolutionizing-car-measurement-data-storage-and-analysis-mercedes-benzs-petabyte-scale).

--- a/docs/impulse/docs/data_model/ingestion.md
+++ b/docs/impulse/docs/data_model/ingestion.md
@@ -5,16 +5,17 @@ title: Ingestion
 
 # Ingestion
 
-Impulse's [default solvers](../references/query_engine.md) read from a
-silver layer composed of a minimum of three tables: `container_metrics`,
-`channel_metrics`, and `channels`. Two additional tables, `container_tags`
-and `channel_tags`, are optional but strongly recommended. They carry the contextual metadata that the
-user-facing channel selection API (`query.channel(channel_name="Engine_RPM")`)
-and tag-based container filtering rely on. The full schema is on the
-[Silver Layer ER Diagram](silver_layer_schema.md). This page is for engineers
-who already have measurement data (CSV, MDF4, a vendor-specific binary, or
-Delta with a different shape) and need a starting point for landing it in
-that layout.
+Impulse's [`DefaultSolver`](../references/query_engine.md) reads from a
+silver layer of **three required tables**: `container_metrics`,
+`channel_metrics`, and `channels`. Two further tables, `container_tags`
+and `channel_tags`, are **fully optional** — add them only if you want
+tag-based container filtering or EAV channel selection
+(`query.channel(channel_name="Engine_RPM")`); without `channel_tags`,
+channels are selected directly from columns on `channel_metrics`. The full
+schema is on the [Silver Layer ER Diagram](silver_layer_schema.md). This page
+is for engineers who already have measurement data (CSV, MDF4, a
+vendor-specific binary, or Delta with a different shape) and need a starting
+point for landing it in that layout.
 
 Impulse does not ship an ingestion component. The library reads from the
 silver layer; producing it is your responsibility. **Landing your data in
@@ -39,7 +40,7 @@ below.
 ## 1. The contract
 
 The full schema is on the [ER diagram page](silver_layer_schema.md). When
-ingesting your own data, four invariants matter most:
+ingesting your own data, the required invariants are:
 
 - **`container_id` is the primary key on `container_metrics`** and the
   foreign key on every other table. One container is one recording (one
@@ -48,11 +49,6 @@ ingesting your own data, four invariants matter most:
 - **`(container_id, channel_id)` identifies a channel within a container.**
   Channel IDs are local to their container — `channel_id = 1` in container A
   has nothing to do with `channel_id = 1` in container B.
-- **Tag tables are strict EAV.** `container_tags` is `(container_id, key,
-  value)`; `channel_tags` is `(container_id, channel_id, key, value)`. TSAL
-  selects recordings and signals by tag key, e.g. `query.channel(channel_name=
-  "Engine_RPM")` looks up `channel_tags.value` where `key = 'channel_name'`.
-  If a key is not in the tag table, no expression can find it.
 - **`channels` supports two formats.** The query engine accepts either:
   - **Raw** — one row per sample: `(container_id, channel_id, timestamp,
     value)`.
@@ -61,6 +57,13 @@ ingesting your own data, four invariants matter most:
 
   An optional boolean `is_plausible` column lets the solver drop implausible
   samples when configured to (`drop_implausible_data=True` on `DefaultSolver`).
+
+The **tag tables are optional, strict EAV** — add them only if you want
+tag-based selection. `container_tags` is `(container_id, key, value)`;
+`channel_tags` is `(container_id, channel_id, key, value)`. TSAL then selects
+recordings and signals by tag key, e.g. `query.channel(channel_name="Engine_RPM")`
+looks up `channel_tags.value` where `key = 'channel_name'`. Without
+`channel_tags`, channel selectors match columns on `channel_metrics` instead.
 
 The remaining columns on `container_metrics` and `channel_metrics`
 (timestamps, durations, mean/min/max, etc.) are *not* fixed by the engine —

--- a/docs/impulse/docs/data_model/silver_layer_schema.md
+++ b/docs/impulse/docs/data_model/silver_layer_schema.md
@@ -5,21 +5,28 @@ title: Silver Layer Schema
 
 # Silver Layer Schema
 
-The Silver layer stores measurement data in a normalized, tag-based model.
-Time-series samples live in `channels`; metadata is split across tag
-tables (EAV key-value pairs) and metric tables (pre-computed statistics).
+The Silver layer stores measurement data in a normalized model: time-series
+samples live in `channels`, and metadata lives in companion tables.
 
-The tables and columns on this page describe the **typical
-default-solver shape** — what Impulse's
-[`DefaultSolver`](../references/query_engine.md) expects when
-no [`SolverConfig`](../config/configuration.md#solver-column-mappings-and-filters)
-overrides are applied. The framework hard-requires only a small subset of this shape:
+**You only need three tables to start:** `container_metrics`,
+`channel_metrics`, and `channels`. Everything else is optional —
+`container_tags` and `channel_tags` (EAV tag tables), `channel_mapping`
+(aliases), and `unit_conversion` (per-alias conversion) are add-ons that
+`DefaultSolver` uses only when you configure them. See the
+[Query Engine table requirements](../references/query_engine.md#table-requirements)
+for the full matrix.
 
-- `container_id` on every silver table (engine join key);
-- `(container_id, channel_id)` on the channel-side tables and `channels`;
-- `key`, `value` columns on the tag tables (EAV layout);
-- one of the two `channels` formats below (RLE with `tstart`/`tend` or
-  raw with `timestamp`).
+The tables and columns on this page describe the **typical default-solver
+shape** — what `DefaultSolver` expects when no
+[`SolverConfig`](../config/configuration.md#solver-column-mappings-and-filters)
+overrides are applied. The framework hard-requires only a small subset:
+
+- `container_id` on every silver table you provide (engine join key);
+- `(container_id, channel_id)` on `channel_metrics`, `channels`, and (if used)
+  `channel_tags`;
+- one of the two `channels` formats below (RLE with `tstart`/`tend` or raw
+  with `timestamp`);
+- `key`, `value` columns **on the tag tables, only if you use them** (EAV layout).
 
 `container_id` may be any Spark type (e.g. `long`, `int`, or `string`): the
 engine derives its type from your tables at query time and carries it through
@@ -173,10 +180,12 @@ the epoch-typed pair). Populate whichever your queries and
 
 ---
 
-## container_tags
+## container_tags (optional)
 
-Key-value metadata tags for measurement containers. Strict EAV layout —
-TSAL queries select recordings by tag key (e.g.
+**Optional** — only needed for tag-based container filtering. Omit it for the
+wide-only model, where container attributes live as columns on
+`container_metrics`. Key-value metadata tags for measurement containers, strict
+EAV layout — TSAL queries select recordings by tag key (e.g.
 `query.havingTag(vehicle_key="Seat_Leon")` looks up `value` where
 `key = 'vehicle_key'`).
 
@@ -274,12 +283,13 @@ when your physical column has a different name.
 
 ---
 
-## channel_tags
+## channel_tags (optional)
 
-Key-value metadata tags per channel. Strict EAV layout — TSAL channel
-selectors look up signals by tag key (e.g.
-`query.channel(channel_name="Engine_RPM")` looks up `value` where
-`key = 'channel_name'`).
+**Optional** — only needed for EAV channel selection. Omit it to select channels
+directly from columns on `channel_metrics` (e.g. a `channel_name` column). Key-value
+metadata tags per channel, strict EAV layout — TSAL channel selectors look up
+signals by tag key (e.g. `query.channel(channel_name="Engine_RPM")` looks up
+`value` where `key = 'channel_name'`).
 
 | Column         | Type     | Nullable | Description                                            |
 |----------------|----------|----------|--------------------------------------------------------|

--- a/docs/impulse/docs/data_model/silver_layer_schema.md
+++ b/docs/impulse/docs/data_model/silver_layer_schema.md
@@ -8,13 +8,17 @@ title: Silver Layer Schema
 The Silver layer stores measurement data in a normalized model: time-series
 samples live in `channels`, and metadata lives in companion tables.
 
-**You only need three tables to start:** `container_metrics`,
+:::tip Start with three tables
+
+You only need three tables to start: `container_metrics`,
 `channel_metrics`, and `channels`. Everything else is optional —
 `container_tags` and `channel_tags` (EAV tag tables), `channel_mapping`
 (aliases), and `unit_conversion` (per-alias conversion) are add-ons that
 `DefaultSolver` uses only when you configure them. See the
 [Query Engine table requirements](../references/query_engine.md#table-requirements)
 for the full matrix.
+
+:::
 
 The tables and columns on this page describe the **typical default-solver
 shape** — what `DefaultSolver` expects when no


### PR DESCRIPTION
- Updated the Data Model documentation to emphasize the three required tables (`container_metrics`, `channel_metrics`, `channels`) and the optional nature of tag tables (`container_tags`, `channel_tags`).
- Enhanced the Ingestion guide to clarify the role of required invariants and the optionality of tag tables for EAV selection.
- Revised the Silver Layer Schema documentation to reflect the simplified structure and requirements for the DefaultSolver, ensuring consistency across all related documents.

## Summary

<!-- Brief description of the changes -->

## Changes

- 

## Test Plan

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Documentation updated (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No new linter warnings introduced
