### PR TITLE
Add PointsInTimeEvent class and update event handling

### DIFF
--- a/docs/impulse/docs/references/report/aggregation.md
+++ b/docs/impulse/docs/references/report/aggregation.md
@@ -10,6 +10,13 @@ Impulse provides three aggregation types: **Histogram**, **Histogram2D**, and **
 
 Aggregations are organized into **Pages**, which group related visuals within a report.
 
+:::note Expression types
+Aggregation signal inputs — `base_expr`, `x_expr`, `y_expr`, `weights_expr`, and each element of
+`input_expressions` — must evaluate to a **`SampleSeries`** (a channel-like signal). This is validated when
+the aggregation is constructed; passing an expression that evaluates to something else (e.g. an `Intervals`
+comparison or a `PointsInTime`) raises a `ValueError`.
+:::
+
 ---
 
 ## Page

--- a/docs/impulse/docs/references/report/event.md
+++ b/docs/impulse/docs/references/report/event.md
@@ -157,6 +157,38 @@ idle_to_drive = SequenceOfEvents(
 
 ---
 
+## PointsInTimeEvent
+
+A `PointsInTimeEvent` derives event instances from a TSAL expression that evaluates to a
+`PointsInTime` (a set of instants) — typically `channel.rising_edges()` or `channel.falling_edges()`.
+Each instant becomes one **zero-duration** event instance (`start_ts == end_ts`), in contrast to
+[`BasicEvent`](#basicevent), which produces durationed intervals.
+
+```python
+from impulse_reporting.events.points_in_time_event import PointsInTimeEvent
+
+eng_rpm = my_report.get_db().query.channel(channel_name="Engine RPM")
+rpm_rising = PointsInTimeEvent(
+    name="rpm_rising_edges",
+    expr=eng_rpm.rising_edges(),
+    desc="Instants where engine RPM rises",
+)
+my_report.add_event(rpm_rising)
+```
+
+### How it works
+
+1. The expression is solved against the report's wide DataFrame, producing a flat array of timestamps.
+2. Each timestamp is materialized as one event instance with `start_ts == end_ts` in the shared
+   `event_instance_fact` table.
+
+The expression **must** evaluate to a `PointsInTime`; otherwise construction raises a `ValueError`
+(use [`BasicEvent`](#basicevent) for an `Intervals` condition). Point instances share
+`event_instance_fact` with interval events — distinguish them by joining `event_dimension` on
+`event_id` and filtering `event_type == "POINTS_IN_TIME_EVENT"`, or by the `start_ts == end_ts` property.
+
+---
+
 ## Event output schema
 
 ### event_dimension
@@ -167,7 +199,7 @@ Stores event definitions (one row per event per report).
 |---------------------|---------------------|-----------------------------------------------------------------------------|
 | `event_id`          | `int`               | Unique event identifier (CRC32 hash of name + expression).                  |
 | `report_id`         | `int`               | Report identifier.                                                          |
-| `event_type`        | `str`               | `"BASIC_EVENT"`, `"CONTAINER_EVENT"`, or `"SEQUENCE_OF_EVENTS"`.             |
+| `event_type`        | `str`               | `"BASIC_EVENT"`, `"CONTAINER_EVENT"`, `"SEQUENCE_OF_EVENTS"`, or `"POINTS_IN_TIME_EVENT"`. |
 | `event_name`        | `str`               | Event name.                                                                 |
 | `event_description` | `str`               | Event description.                                                          |
 | `required_channels` | `array[str]`        | Required channel names (null for `ContainerEvent`).                         |
@@ -187,12 +219,16 @@ Stores materialized event occurrences (one row per event instance per container)
 | `start_ts`          | `long` | Event instance start timestamp.          |
 | `end_ts`            | `long` | Event instance end timestamp.            |
 
+Interval events satisfy `start_ts < end_ts`; `PointsInTimeEvent` instances are zero-duration
+(`start_ts == end_ts`).
+
 ---
 
 ## Choosing between event types
 
-| Criterion                        | BasicEvent                                              | ContainerEvent                                    | SequenceOfEvents                                                          |
-|----------------------------------|---------------------------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------|
-| Requires a TSAL expression       | Yes (one)                                               | No                                                | Yes (ordered list)                                                        |
-| Multiple instances per container | Yes (one per matching interval)                         | No (always one per container)                     | Yes (one per joined sequence)                                             |
-| Use case                         | Signal-based conditions, operating bands, distance bins | Full-run aggregations, container-level statistics | State transitions and multi-step patterns where consecutive states overlap |
+| Criterion                        | BasicEvent                                              | ContainerEvent                                    | SequenceOfEvents                                                          | PointsInTimeEvent                                          |
+|----------------------------------|---------------------------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------|------------------------------------------------------------|
+| Requires a TSAL expression       | Yes (one)                                               | No                                                | Yes (ordered list)                                                        | Yes (one, must evaluate to `PointsInTime`)                 |
+| Multiple instances per container | Yes (one per matching interval)                         | No (always one per container)                     | Yes (one per joined sequence)                                             | Yes (one per instant)                                      |
+| Instance duration                | Interval (`start_ts < end_ts`)                          | Full container window                             | Interval (`start_ts < end_ts`)                                            | Zero (`start_ts == end_ts`)                                |
+| Use case                         | Signal-based conditions, operating bands, distance bins | Full-run aggregations, container-level statistics | State transitions and multi-step patterns where consecutive states overlap | Edge/instant events, e.g. `rising_edges()` / `falling_edges()` |

--- a/docs/impulse/docs/references/report/event.md
+++ b/docs/impulse/docs/references/report/event.md
@@ -40,7 +40,7 @@ eng_rpm_event = BasicEvent(
 | Parameter           | Type                   | Required | Description                                                                                          |
 |---------------------|------------------------|----------|------------------------------------------------------------------------------------------------------|
 | `name`              | `str`                  | Yes      | Unique event name. Used as identifier in fact and dimension tables.                                  |
-| `expr`              | `TimeSeriesExpression` | Yes      | Boolean TSAL expression defining the event condition. Must resolve to `Intervals` at execution time. |
+| `expr`              | `TimeSeriesExpression` | Yes      | Boolean TSAL expression defining the event condition. Must evaluate to `Intervals`; validated at construction (raises `ValueError` otherwise). |
 | `desc`              | `str`                  | No       | Human-readable description stored in the event dimension table.                                      |
 | `required_channels` | `list[str]`            | No       | Channel names required for this event. Informational; stored in the event dimension table.           |
 | `attributes`        | `Mapping[str, str]`    | No       | Free-form key-value metadata stored in the event dimension table (e.g. `limit_type`, `limit_direction`). Values are coerced to strings. |
@@ -141,7 +141,7 @@ idle_to_drive = SequenceOfEvents(
 | Parameter           | Type                          | Required | Description                                                                                                                                                                  |
 |---------------------|-------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`              | `str`                         | Yes      | Unique event name.                                                                                                                                                           |
-| `expressions`       | `list[TimeSeriesExpression]`  | Yes      | Ordered list of expressions. Each must resolve to `Intervals`.                                                                                                               |
+| `expressions`       | `list[TimeSeriesExpression]`  | Yes      | Ordered list of expressions. Each must evaluate to `Intervals`; validated at construction (raises `ValueError` otherwise).                                                   |
 | `desc`              | `str`                         | No       | Human-readable description.                                                                                                                                                  |
 | `required_channels` | `list[str]`                   | No       | Channel names required for this event. Informational; stored in the event dimension table.                                                                                   |
 | `max_overlap`       | `float`                       | No       | Maximum allowed overlap between consecutive intervals. Sequences whose overlap exceeds this value are skipped. Expressed in the same time unit as the underlying timestamps. |

--- a/src/impulse_query_engine/analyze/metadata/time_series_expression.py
+++ b/src/impulse_query_engine/analyze/metadata/time_series_expression.py
@@ -79,6 +79,35 @@ class TimeSeriesExpression(abc.ABC):
 
         return type(self.build(EmptyTimeSeriesCache()))
 
+    def require_evaluation_type(
+        self, expected: type, *, owner: str, example: str | None = None
+    ) -> None:
+        """
+        Validate that this expression evaluates to ``expected``; raise otherwise.
+
+        Parameters
+        ----------
+        expected : type
+            Required core-model class (e.g. ``Intervals``, ``SampleSeries``,
+            ``PointsInTime``).
+        owner : str
+            Caller name, used in the error message (e.g. ``"BasicEvent"``).
+        example : str, optional
+            Short example of a valid expression, appended as a hint.
+
+        Raises
+        ------
+        ValueError
+            If the expression does not evaluate to ``expected``.
+        """
+        actual = self.evaluation_type()
+        if actual is not expected:
+            hint = f" (e.g. {example})" if example else ""
+            raise ValueError(
+                f"{owner} requires an expression that evaluates to "
+                f"{expected.__name__}{hint}; got {actual.__name__}"
+            )
+
     def __getstate__(self):  # overwrite to avoid errors from __getattr__
         return self.__dict__
 

--- a/src/impulse_query_engine/analyze/metadata/time_series_expression.py
+++ b/src/impulse_query_engine/analyze/metadata/time_series_expression.py
@@ -61,6 +61,24 @@ class TimeSeriesExpression(abc.ABC):
         """
         return T.DoubleType()
 
+    def evaluation_type(self) -> type:
+        """
+        Return the core-model class this expression evaluates to.
+
+        Builds the expression against an empty cache (cheap, no Spark and no data) and returns the
+        resulting object's type -- e.g. ``SampleSeries``, ``Intervals``, ``PointsInTime``,
+        ``PointsInTimeSeries``, or a numeric type for scalar aggregations. Useful for validating up
+        front that an expression evaluates to an expected type.
+
+        Returns
+        -------
+        type
+            The type of the object the expression evaluates to.
+        """
+        from impulse_query_engine.analyze.query.solvers.empty_cache import EmptyTimeSeriesCache
+
+        return type(self.build(EmptyTimeSeriesCache()))
+
     def __getstate__(self):  # overwrite to avoid errors from __getattr__
         return self.__dict__
 

--- a/src/impulse_reporting/aggregations/histogram.py
+++ b/src/impulse_reporting/aggregations/histogram.py
@@ -12,6 +12,7 @@ from impulse_query_engine.analyze.metadata.time_series_expression import (
 )
 from impulse_query_engine.analyze.query.query_builder import QueryBuilder
 from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+from impulse_query_engine.model.series.sample_series import SampleSeries
 from impulse_reporting.aggregations.aggregation import Aggregation
 from impulse_reporting.events.event import Event
 from impulse_reporting.persist.dimension_schema import HISTOGRAM_DIMENSION_SCHEMA
@@ -60,6 +61,9 @@ class Histogram(Aggregation, ABC):
         """
         Aggregation.__init__(self, name)
         self.base_expr = base_expr
+        self.base_expr.require_evaluation_type(
+            SampleSeries, owner=type(self).__name__, example="a channel selection"
+        )
         self.bins = bins
         self.event = event
         self.desc = desc
@@ -416,6 +420,9 @@ class HistogramCustomWeights(Histogram):
             bins_unit,
         )
         self.weights_expr = weights_expr
+        self.weights_expr.require_evaluation_type(
+            SampleSeries, owner=type(self).__name__, example="a channel selection"
+        )
         self.weights_channel_name = weights_channel_name
         self.channel_interp_kind = channel_interp_kind
         self.weights_interp_kind = weights_interp_kind

--- a/src/impulse_reporting/aggregations/histogram2d.py
+++ b/src/impulse_reporting/aggregations/histogram2d.py
@@ -13,6 +13,7 @@ from impulse_query_engine.analyze.metadata.time_series_expression import (
 )
 from impulse_query_engine.analyze.query.query_builder import QueryBuilder
 from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+from impulse_query_engine.model.series.sample_series import SampleSeries
 from impulse_reporting.aggregations.aggregation import Aggregation
 from impulse_reporting.events.event import Event
 from impulse_reporting.persist.dimension_schema import HISTOGRAM2D_DIMENSION_SCHEMA
@@ -73,6 +74,12 @@ class Histogram2D(Aggregation, ABC):
         Aggregation.__init__(self, name)
         self.x_expr = x_expr
         self.y_expr = y_expr
+        self.x_expr.require_evaluation_type(
+            SampleSeries, owner=type(self).__name__, example="a channel selection"
+        )
+        self.y_expr.require_evaluation_type(
+            SampleSeries, owner=type(self).__name__, example="a channel selection"
+        )
         self.x_bins = x_bins
         self.y_bins = y_bins
         self.event = event
@@ -634,6 +641,9 @@ class Histogram2DCustomWeights(Histogram2D):
             y_bins_unit=y_bins_unit,
         )
         self.weights_expr = weights_expr
+        self.weights_expr.require_evaluation_type(
+            SampleSeries, owner=type(self).__name__, example="a channel selection"
+        )
         self.weights_channel_name = weights_channel_name
         self.channel_interp_kind = channel_interp_kind
         self.weights_interp_kind = weights_interp_kind

--- a/src/impulse_reporting/aggregations/stats_aggregator.py
+++ b/src/impulse_reporting/aggregations/stats_aggregator.py
@@ -20,6 +20,7 @@ from impulse_query_engine.analyze.query.aggregations.stats_aggregator import (
 )
 from impulse_query_engine.analyze.query.query_builder import QueryBuilder
 from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+from impulse_query_engine.model.series.sample_series import SampleSeries
 from impulse_reporting.aggregations.aggregation import Aggregation
 from impulse_reporting.events.event import Event
 from impulse_reporting.persist.dimension_schema import STATS_AGGREGATOR_DIMENSION_SCHEMA
@@ -73,6 +74,10 @@ class StatsAggregator(Aggregation):
         self.input_expressions = input_expressions
         self.channel_names = channel_names
         self._validate_channel_names()
+        for expr in self.input_expressions:
+            expr.require_evaluation_type(
+                SampleSeries, owner="StatsAggregator", example="a channel selection"
+            )
         self.statistics = statistics
         self.event = event
         self.desc = desc

--- a/src/impulse_reporting/events/basic_event.py
+++ b/src/impulse_reporting/events/basic_event.py
@@ -12,6 +12,7 @@ from impulse_query_engine.analyze.metadata.time_series_expression import (
 )
 from impulse_query_engine.analyze.query.query_builder import QueryBuilder
 from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+from impulse_query_engine.model.series.intervals import Intervals
 from impulse_reporting.events.event import Event
 from impulse_reporting.persist.dimension_schema import EVENT_DIMENSION_SCHEMA
 from impulse_reporting.persist.fact_schema import EVENT_INSTANCE_FACT_SCHEMA
@@ -48,6 +49,9 @@ class BasicEvent(Event):
         """
         Event.__init__(self, name)
         self.expression = expr.alias(name)
+        self.expression.require_evaluation_type(
+            Intervals, owner="BasicEvent", example="(channel > 2000) & (channel < 5000)"
+        )
         self.description = desc
         self.required_channels = required_channels
         normalized_attributes: dict[str, str] = {}

--- a/src/impulse_reporting/events/event_types.py
+++ b/src/impulse_reporting/events/event_types.py
@@ -4,6 +4,7 @@ from pyspark.sql.types import StructType
 
 from impulse_reporting.events.basic_event import BasicEvent
 from impulse_reporting.events.container_event import ContainerEvent
+from impulse_reporting.events.points_in_time_event import PointsInTimeEvent
 from impulse_reporting.events.sequence_of_events import SequenceOfEvents
 from impulse_reporting.persist.dimension_schema import EVENT_DIMENSION_SCHEMA
 from impulse_reporting.persist.fact_schema import EVENT_INSTANCE_FACT_SCHEMA
@@ -30,6 +31,7 @@ class EventType(Enum):
     BASIC_EVENT = BasicEvent
     CONTAINER_EVENT = ContainerEvent
     SEQUENCE_OF_EVENTS = SequenceOfEvents
+    POINTS_IN_TIME_EVENT = PointsInTimeEvent
 
     def get_fact_table_name(self) -> str:
         """
@@ -46,7 +48,12 @@ class EventType(Enum):
             If the event type is not supported.
         """
         match self:
-            case EventType.BASIC_EVENT | EventType.CONTAINER_EVENT | EventType.SEQUENCE_OF_EVENTS:
+            case (
+                EventType.BASIC_EVENT
+                | EventType.CONTAINER_EVENT
+                | EventType.SEQUENCE_OF_EVENTS
+                | EventType.POINTS_IN_TIME_EVENT
+            ):
                 return "event_instance_fact"
             case _:
                 raise ValueError(f"Unsupported event type: {self}")
@@ -66,7 +73,12 @@ class EventType(Enum):
             If the event type is not supported.
         """
         match self:
-            case EventType.BASIC_EVENT | EventType.CONTAINER_EVENT | EventType.SEQUENCE_OF_EVENTS:
+            case (
+                EventType.BASIC_EVENT
+                | EventType.CONTAINER_EVENT
+                | EventType.SEQUENCE_OF_EVENTS
+                | EventType.POINTS_IN_TIME_EVENT
+            ):
                 return EVENT_INSTANCE_FACT_SCHEMA
             case _:
                 raise ValueError(f"Unsupported event type: {self}")
@@ -86,7 +98,12 @@ class EventType(Enum):
             If the event type is not supported.
         """
         match self:
-            case EventType.BASIC_EVENT | EventType.CONTAINER_EVENT | EventType.SEQUENCE_OF_EVENTS:
+            case (
+                EventType.BASIC_EVENT
+                | EventType.CONTAINER_EVENT
+                | EventType.SEQUENCE_OF_EVENTS
+                | EventType.POINTS_IN_TIME_EVENT
+            ):
                 return "event_dimension"
             case _:
                 raise ValueError(f"Unsupported aggregation type: {self}")
@@ -104,7 +121,12 @@ class EventType(Enum):
             If the event type is not supported.
         """
         match self:
-            case EventType.BASIC_EVENT | EventType.CONTAINER_EVENT | EventType.SEQUENCE_OF_EVENTS:
+            case (
+                EventType.BASIC_EVENT
+                | EventType.CONTAINER_EVENT
+                | EventType.SEQUENCE_OF_EVENTS
+                | EventType.POINTS_IN_TIME_EVENT
+            ):
                 return EVENT_DIMENSION_SCHEMA
             case _:
                 raise ValueError(f"Unsupported event type: {self}")

--- a/src/impulse_reporting/events/points_in_time_event.py
+++ b/src/impulse_reporting/events/points_in_time_event.py
@@ -60,12 +60,9 @@ class PointsInTimeEvent(Event):
         """
         Event.__init__(self, name)
         self.expression = expr.alias(name)
-        if self.expression.evaluation_type() is not PointsInTime:
-            raise ValueError(
-                "PointsInTimeEvent requires an expression that evaluates to PointsInTime "
-                f"(e.g. channel.rising_edges()); got "
-                f"{self.expression.evaluation_type().__name__}"
-            )
+        self.expression.require_evaluation_type(
+            PointsInTime, owner="PointsInTimeEvent", example="channel.rising_edges()"
+        )
         self.description = desc
         self.required_channels = required_channels
         normalized_attributes: dict[str, str] = {}

--- a/src/impulse_reporting/events/points_in_time_event.py
+++ b/src/impulse_reporting/events/points_in_time_event.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+
+import pyspark.sql.functions as f
+import zlib
+from pyspark.sql import Row, SparkSession
+
+from impulse_query_engine.analyze.metadata.time_series_expression import (
+    TimeSeriesExpression,
+)
+from impulse_query_engine.analyze.query.query_builder import QueryBuilder
+from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+from impulse_query_engine.model.series.points_in_time import PointsInTime
+from impulse_reporting.events.event import Event
+from impulse_reporting.persist.dimension_schema import EVENT_DIMENSION_SCHEMA
+from impulse_reporting.persist.fact_schema import EVENT_INSTANCE_FACT_SCHEMA
+from impulse_reporting.util.event_instance_util import generate_event_instance_id_column
+from impulse_reporting.util.report_entity_util import ReportEntityUtil
+
+
+class PointsInTimeEvent(Event):
+    """Class representing an event whose expression evaluates to a ``PointsInTime``.
+
+    Each point in time becomes one zero-duration event instance (``start_ts == end_ts``) written to
+    the ``event_instance_fact`` table. This is the point-wise counterpart of ``BasicEvent`` (which
+    expects an ``Intervals`` expression); a typical expression is ``channel.rising_edges()``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        expr: TimeSeriesExpression,
+        desc: str = None,
+        required_channels: list[str] = None,
+        attributes: Mapping[str, str] = None,
+    ):
+        """
+        Initialize a PointsInTimeEvent object.
+
+        Parameters
+        ----------
+        name : str
+            Name of the event.
+        expr : TimeSeriesExpression
+            Time series expression for the event. Must evaluate to a ``PointsInTime``
+            (e.g. ``channel.rising_edges()``).
+        desc : str, optional
+            Description of the event.
+        required_channels : list of str, optional
+            List of required channels for the event.
+        attributes : Mapping[str, str], optional
+            Key-value metadata for the event (e.g. limit_type, limit_direction).
+
+        Raises
+        ------
+        ValueError
+            If ``expr`` does not evaluate to a ``PointsInTime``.
+        """
+        Event.__init__(self, name)
+        self.expression = expr.alias(name)
+        if self.expression.evaluation_type() is not PointsInTime:
+            raise ValueError(
+                "PointsInTimeEvent requires an expression that evaluates to PointsInTime "
+                f"(e.g. channel.rising_edges()); got "
+                f"{self.expression.evaluation_type().__name__}"
+            )
+        self.description = desc
+        self.required_channels = required_channels
+        normalized_attributes: dict[str, str] = {}
+        if attributes is not None:
+            normalized_attributes = {str(k): str(v) for k, v in attributes.items()}
+        self.attributes = normalized_attributes
+
+    def get_id(self) -> int:
+        """
+        Returns a unique identifier for the event.
+
+        Returns
+        -------
+        int
+            Unique positive 32-bit integer identifier for the event.
+        """
+        hash_input = f"{self.name}"
+        return zlib.crc32(hash_input.encode()) & 0x7FFFFFFF  # Ensures positive 32-bit int
+
+    def get_expression(self) -> TimeSeriesExpression | None:
+        """
+        Get the time series expression associated with the event.
+
+        Returns
+        -------
+        TimeSeriesExpression or None
+            The time series expression for the event.
+        """
+        return self.expression
+
+    def get_event_type_str(self) -> str:
+        """Get the event type string for PointsInTimeEvent.
+
+        Returns
+        -------
+        str
+            Event type string.
+        """
+        return "POINTS_IN_TIME_EVENT"
+
+    def determine_definition_hash(self) -> int:
+        """
+        Calculate definition hash for the point-in-time event.
+
+        Only includes the expression (computation logic), which is the
+        only attribute that affects the event results.
+
+        Excludes: name, description, required_channels, report_id
+
+        Returns
+        -------
+        int
+            Hash value representing the computation definition.
+        """
+        # Only the expression affects results
+        hash_input = self.get_expression_str()
+
+        # Use SHA-256 and return as int (truncated to fit LongType)
+        hash_bytes = hashlib.sha256(hash_input.encode()).digest()
+        return int.from_bytes(hash_bytes[:8], byteorder="big", signed=True)
+
+    def as_dict(self) -> dict:
+        """
+        Get a dictionary representation of the event.
+
+        Returns
+        -------
+        dict
+            Dictionary containing event metadata.
+        """
+        return {
+            "event_id": self.get_id(),
+            "report_id": self.report_id,
+            "event_type": self.get_event_type_str(),
+            "event_name": self.name,
+            "event_description": self.description,
+            "required_channels": self.required_channels,
+            "event_expression": self.get_expression_str(),
+            "definition_hash": self.determine_definition_hash(),
+            "attributes": self.attributes,
+        }
+
+    def as_spark_row(self) -> Row:
+        """
+        Get a Spark Row representation of the event.
+
+        Returns
+        -------
+        Row
+            Spark Row containing event metadata.
+        """
+        return Row(**self.as_dict())
+
+    @classmethod
+    def determine_events(
+        cls,
+        spark: SparkSession,
+        events: list[PointsInTimeEvent],
+        *,
+        solved_df: "DataFrame" = None,
+        query: QueryBuilder = None,
+        solver: QuerySolver = None,
+        pre_filtered_containers_df=None,
+    ):
+        """
+        Extract the event fact table for the given list of PointsInTimeEvent objects.
+
+        Each point in time becomes one zero-duration instance (``start_ts == end_ts``). The
+        expression result is a flat array of timestamps (``PointsInTime``), so it is exploded into
+        one row per timestamp; the ``start_ts < end_ts`` filter used by interval events is
+        deliberately omitted (it would drop every point).
+
+        Parameters
+        ----------
+        spark : SparkSession
+            Spark session for data processing.
+        events : list of PointsInTimeEvent
+            List of PointsInTimeEvent objects to process.
+        solved_df : DataFrame, optional
+            Pre-solved wide DataFrame from centralized batch solve. Required.
+        query : QueryBuilder, optional
+            Query builder (unused, kept for interface compatibility).
+        solver : QuerySolver, optional
+            Query solver (unused, kept for interface compatibility).
+        pre_filtered_containers_df : DataFrame, optional
+            Pre-filtered containers for incremental processing.
+
+        Returns
+        -------
+        DataFrame
+            Spark DataFrame containing event instance facts.
+        """
+        if solved_df is None:
+            raise ValueError(
+                "PointsInTimeEvent.determine_events requires solved_df. "
+                "Provide a pre-solved DataFrame from the centralized batch-solve flow."
+            )
+
+        event_names = [event.get_name() for event in events]
+
+        df = (
+            solved_df.select("container_id", *event_names)
+            .unpivot(
+                f.col("container_id"),
+                event_names,
+                variableColumnName="event_name",
+                valueColumnName="value",
+            )
+            .select(
+                "container_id",
+                "event_name",
+                f.explode(f.col("value")).alias("ts"),
+            )
+            .withColumn("start_ts", f.col("ts").cast("long"))
+            .withColumn("end_ts", f.col("ts").cast("long"))
+            .withColumn(
+                "event_instance_id",
+                generate_event_instance_id_column(event_type=PointsInTimeEvent),
+            )
+            .withColumn(
+                "event_id",
+                ReportEntityUtil.get_event_id_column(elements=events, element_name="event_name"),
+            )
+            .select(EVENT_INSTANCE_FACT_SCHEMA.fieldNames())
+        )
+        return df
+
+    @classmethod
+    def determine_metadata_df(cls, spark: SparkSession, events: list[PointsInTimeEvent]):
+        """
+        Create a Spark DataFrame containing event metadata.
+
+        Parameters
+        ----------
+        spark : SparkSession
+            Spark session for data processing.
+        events : list of PointsInTimeEvent
+            List of PointsInTimeEvent objects.
+
+        Returns
+        -------
+        DataFrame
+            Spark DataFrame containing event metadata.
+        """
+        events = [event.as_spark_row() for event in events]
+        return spark.createDataFrame(events, schema=EVENT_DIMENSION_SCHEMA)

--- a/src/impulse_reporting/events/sequence_of_events.py
+++ b/src/impulse_reporting/events/sequence_of_events.py
@@ -13,6 +13,7 @@ from impulse_query_engine.analyze.metadata.time_series_expression import (
 from impulse_query_engine.analyze.query.events import SequenceOfEventsExpression
 from impulse_query_engine.analyze.query.query_builder import QueryBuilder
 from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+from impulse_query_engine.model.series.intervals import Intervals
 from impulse_reporting.events.event import Event
 from impulse_reporting.persist.dimension_schema import EVENT_DIMENSION_SCHEMA
 from impulse_reporting.persist.fact_schema import EVENT_INSTANCE_FACT_SCHEMA
@@ -66,6 +67,10 @@ class SequenceOfEvents(Event):
             any other derived unit.
         """
         Event.__init__(self, name)
+        for expr in expressions:
+            expr.require_evaluation_type(
+                Intervals, owner="SequenceOfEvents", example="channel > 0"
+            )
         self.expression = SequenceOfEventsExpression(expressions, max_overlap=max_overlap).alias(
             name
         )

--- a/tests/impulse_query_engine/unit/analyze/query/query_builder_test.py
+++ b/tests/impulse_query_engine/unit/analyze/query/query_builder_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-function-docstring, redefined-outer-name
 import pyspark.sql.types as T
+import pytest
 
 from impulse_query_engine.analyze.metadata.tag_expression import TagSelector
 from impulse_query_engine.analyze.metadata.time_series_expression import (
@@ -92,6 +93,26 @@ def test_evaluation_type_points_in_time_series():
 def test_evaluation_type_scalar():
     # scalar aggregations evaluate to a (numpy) float; np.float64 subclasses float
     assert issubclass(_eval_ts().mean().evaluation_type(), float)
+
+
+# ---------------------------------------------------------------------------
+# TimeSeriesExpression.require_evaluation_type (raises on mismatch)
+# ---------------------------------------------------------------------------
+def test_require_evaluation_type_passes_on_match():
+    # returns None and does not raise when the type matches
+    assert _eval_ts().require_evaluation_type(SampleSeries, owner="Test") is None
+
+
+def test_require_evaluation_type_raises_on_mismatch():
+    with pytest.raises(
+        ValueError, match="Owner requires an expression that evaluates to Intervals"
+    ):
+        _eval_ts().require_evaluation_type(Intervals, owner="Owner")
+
+
+def test_require_evaluation_type_reports_actual_and_example():
+    with pytest.raises(ValueError, match="got SampleSeries"):
+        _eval_ts().require_evaluation_type(Intervals, owner="Owner", example="channel > 0")
 
 
 def test_multiple_selections_dtype(narrow_db):

--- a/tests/impulse_query_engine/unit/analyze/query/query_builder_test.py
+++ b/tests/impulse_query_engine/unit/analyze/query/query_builder_test.py
@@ -65,6 +65,35 @@ def test_pointsInTimeSeries_dtype(narrow_db):
     assert isinstance(result_objects[0], PointsInTimeSeries)
 
 
+# ---------------------------------------------------------------------------
+# TimeSeriesExpression.evaluation_type (builds against an empty cache, no Spark)
+# ---------------------------------------------------------------------------
+def _eval_ts():
+    return TimeSeriesSelector(TagSelector("name") == "test")
+
+
+def test_evaluation_type_sample_series():
+    assert _eval_ts().evaluation_type() is SampleSeries
+
+
+def test_evaluation_type_intervals():
+    assert (_eval_ts() > 0).evaluation_type() is Intervals
+
+
+def test_evaluation_type_points_in_time():
+    assert _eval_ts().rising_edge().evaluation_type() is PointsInTime
+
+
+def test_evaluation_type_points_in_time_series():
+    ts = _eval_ts()
+    assert ts.where(ts.rising_edge()).evaluation_type() is PointsInTimeSeries
+
+
+def test_evaluation_type_scalar():
+    # scalar aggregations evaluate to a (numpy) float; np.float64 subclasses float
+    assert issubclass(_eval_ts().mean().evaluation_type(), float)
+
+
 def test_multiple_selections_dtype(narrow_db):
     query = narrow_db.query
     ts1 = TimeSeriesSelector(TagSelector("name") == "test_1")

--- a/tests/impulse_reporting/integration/points_in_time_event_test.py
+++ b/tests/impulse_reporting/integration/points_in_time_event_test.py
@@ -1,0 +1,60 @@
+import os
+from unittest.mock import create_autospec
+
+import pyspark.sql.functions as F
+from databricks.sdk import WorkspaceClient
+
+from impulse_reporting.core.report import Report
+from impulse_reporting.events.points_in_time_event import PointsInTimeEvent
+
+
+def test_persist_points_in_time_event(spark):
+    """End-to-end: a PointsInTimeEvent writes zero-duration rows to event_instance_fact, and its
+    event_type lands in event_dimension."""
+    base_path = os.path.dirname(os.path.abspath(__file__))
+    base_path = base_path[: base_path.find("tests")]
+    config_path = os.path.join(base_path, "tests", "data", "config", "config.json")
+
+    my_report: Report = Report(
+        name="my_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config_path=config_path,
+    )
+
+    eng_rpm = my_report.get_db().query.channel(channel_name="Engine RPM")
+    pit_event = PointsInTimeEvent(
+        name="rpm_rising_edges",
+        expr=eng_rpm.rising_edges(),
+        desc="Engine RPM rising edges",
+    )
+    my_report.add_event(pit_event)
+
+    my_report.determine_report()
+
+    event_dfs = my_report.event_dfs
+    event_metadata_dfs = my_report.event_metadata_dfs
+    assert event_dfs["POINTS_IN_TIME_EVENT"]["changed"].count() > 0
+    assert event_metadata_dfs["POINTS_IN_TIME_EVENT"].count() > 0
+
+    my_report.persist_results()
+
+    assert spark.catalog.tableExists("spark_catalog.gold.evaluation_event_instance_fact")
+    assert spark.catalog.tableExists("spark_catalog.gold.evaluation_event_dimension")
+
+    fact = spark.read.table("spark_catalog.gold.evaluation_event_instance_fact")
+    dim = spark.read.table("spark_catalog.gold.evaluation_event_dimension")
+
+    point_rows = fact.filter(F.col("event_id") == pit_event.get_id())
+    assert point_rows.count() > 0
+    # every point-in-time instance is a zero-duration row
+    assert point_rows.filter(F.col("start_ts") != F.col("end_ts")).count() == 0
+
+    # event_type is persisted in the dimension table (value-level check)
+    assert (
+        dim.filter(
+            (F.col("event_name") == "rpm_rising_edges")
+            & (F.col("event_type") == "POINTS_IN_TIME_EVENT")
+        ).count()
+        == 1
+    )

--- a/tests/impulse_reporting/unit/aggregations/definition_hash_test.py
+++ b/tests/impulse_reporting/unit/aggregations/definition_hash_test.py
@@ -106,7 +106,7 @@ class TestHistogramDefinitionHash:
     def test_hash_with_event_filter(self):
         """Test that hash includes event filter expression."""
         base_expr = TimeSeriesSelector(None)
-        event_expr = TimeSeriesSelector(None)
+        event_expr = TimeSeriesSelector(None) > 0
         event = BasicEvent(name="test_event", expr=event_expr)
         bins = [0.0, 1.0, 2.0]
 

--- a/tests/impulse_reporting/unit/aggregations/histogram2d_test.py
+++ b/tests/impulse_reporting/unit/aggregations/histogram2d_test.py
@@ -49,7 +49,7 @@ def test_histogram2d_init():
 def test_histogram_init_with_optional_params():
     """Test Histogram2D initialization with all optional parameters"""
     base_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     bins = [0.0, 5.0, 10.0]
     hist = Histogram2DDuration(
@@ -107,7 +107,7 @@ def test_get_expression_with_event_expr():
     ts_expr = TimeSeriesSelector(None)
     bins = [0.0, 1.0, 2.0]
 
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     hist = Histogram2DDuration(
@@ -467,7 +467,7 @@ def test_add_event_id_column(spark):
 
     ts_expr = TimeSeriesSelector(None)
     bins = [0.0, 1.0, 2.0]
-    my_event = BasicEvent(name="veh_spd_event", expr=ts_expr, desc="Vehicle speed > 1 km/h")
+    my_event = BasicEvent(name="veh_spd_event", expr=ts_expr > 0, desc="Vehicle speed > 1 km/h")
     hist = Histogram2DDuration(
         name="rpm_vs_speed_hist",
         x_expr=ts_expr,
@@ -697,7 +697,7 @@ def test_histogram2d_custom_weights_init_with_optional_params():
     x_expr = TimeSeriesSelector(None)
     y_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     x_bins = [0.0, 5.0, 10.0]
     y_bins = [0.0, 100.0, 200.0]
@@ -790,7 +790,7 @@ def test_histogram2d_custom_weights_get_expression_with_event():
     weights_expr = TimeSeriesSelector(None)
     bins = [0.0, 1.0, 2.0]
 
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     hist = Histogram2DCustomWeights(
@@ -961,7 +961,7 @@ def test_histogram2d_distance_init_with_optional_params():
     x_expr = TimeSeriesSelector(None)
     y_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     x_bins = [0.0, 5.0, 10.0]
     y_bins = [0.0, 100.0, 200.0]
@@ -1050,7 +1050,7 @@ def test_histogram2d_distance_get_expression_with_event():
     weights_expr = TimeSeriesSelector(None)
     bins = [0.0, 1.0, 2.0]
 
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     hist = Histogram2DDistance(
@@ -1300,7 +1300,7 @@ def test_histogram2d_custom_weights_get_event():
     x_expr = TimeSeriesSelector(None)
     y_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     bins = [0.0, 1.0, 2.0]
 
@@ -1331,7 +1331,7 @@ def test_histogram2d_distance_get_event():
     x_expr = TimeSeriesSelector(None)
     y_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     bins = [0.0, 1.0, 2.0]
 
@@ -1533,7 +1533,7 @@ def test_definition_hash_changes_with_event():
     """Adding an event must change the hash."""
     ts_expr = TimeSeriesSelector(None)
     bins = [0.0, 1.0, 2.0]
-    event = BasicEvent(name="ev", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="ev", expr=TimeSeriesSelector(None) > 0)
     hist_no_event = Histogram2DDuration(
         name="h", x_expr=ts_expr, y_expr=ts_expr, x_bins=bins, y_bins=bins
     )
@@ -1574,3 +1574,28 @@ def test_determine_aggregations_requires_solved_df(spark):
     )
     with pytest.raises(ValueError, match="requires solved_df"):
         Histogram2DDuration.determine_aggregations(spark=spark, aggregations=[hist])
+
+
+def test_init_rejects_non_sample_series_axis_expr():
+    """x_expr / y_expr must evaluate to SampleSeries; an Intervals expression is rejected."""
+    with pytest.raises(ValueError, match="SampleSeries"):
+        Histogram2DDuration(
+            name="bad",
+            x_expr=TimeSeriesSelector(None) > 0,
+            y_expr=TimeSeriesSelector(None),
+            x_bins=[0.0, 1.0],
+            y_bins=[0.0, 1.0],
+        )
+
+
+def test_init_rejects_non_sample_series_weights_expr():
+    """weights_expr must evaluate to SampleSeries; an Intervals expression is rejected."""
+    with pytest.raises(ValueError, match="SampleSeries"):
+        Histogram2DCustomWeights(
+            name="bad",
+            x_expr=TimeSeriesSelector(None),
+            y_expr=TimeSeriesSelector(None),
+            weights_expr=TimeSeriesSelector(None) > 0,
+            x_bins=[0.0, 1.0],
+            y_bins=[0.0, 1.0],
+        )

--- a/tests/impulse_reporting/unit/aggregations/histogram_test.py
+++ b/tests/impulse_reporting/unit/aggregations/histogram_test.py
@@ -39,7 +39,7 @@ def test_histogram_init():
 def test_histogram_init_with_optional_params():
     """Test Histogram initialization with all optional parameters"""
     base_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     bins = [0.0, 5.0, 10.0]
     hist = HistogramDuration(
@@ -84,7 +84,7 @@ def test_get_expression():
 def test_get_expression_with_event_expr():
     """Test expression creation when event is provided"""
     base_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     hist = HistogramDuration(name="test", base_expr=base_expr, bins=[0.0, 1.0], event=basic_event)
     expression = hist.get_expression()
@@ -309,7 +309,7 @@ def test_histogram_custom_weights_init_with_optional_params():
     """Test HistogramCustomWeights initialization with all optional parameters"""
     base_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     bins = [0.0, 5.0, 10.0]
     hist = HistogramCustomWeights(
@@ -379,7 +379,7 @@ def test_histogram_custom_weights_get_expression_with_event():
     """Test expression creation when event is provided for HistogramCustomWeights"""
     base_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     hist = HistogramCustomWeights(
         name="test",
@@ -612,7 +612,7 @@ def test_histogram_custom_weights_get_event():
     """Test get_event method for HistogramCustomWeights"""
     base_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     # Test with event
@@ -700,7 +700,7 @@ def test_histogram_distance_init_with_optional_params():
     """Test HistogramDistance initialization with all optional parameters"""
     base_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     bins = [0.0, 5.0, 10.0]
     hist = HistogramDistance(
@@ -765,7 +765,7 @@ def test_histogram_distance_get_expression_with_event():
     """Test expression creation when event is provided for HistogramDistance"""
     base_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     hist = HistogramDistance(
         name="test",
@@ -997,7 +997,7 @@ def test_histogram_distance_get_event():
     """Test get_event method for HistogramDistance"""
     base_expr = TimeSeriesSelector(None)
     weights_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     # Test with event
@@ -1133,7 +1133,7 @@ def test_definition_hash_changes_with_event():
     """Adding an event must change the hash."""
     base_expr = TimeSeriesSelector(None)
     bins = [0.0, 1.0, 2.0]
-    event = BasicEvent(name="ev", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="ev", expr=TimeSeriesSelector(None) > 0)
     hist_no_event = HistogramDuration(name="h", base_expr=base_expr, bins=bins)
     hist_with_event = HistogramDuration(name="h", base_expr=base_expr, bins=bins, event=event)
     assert hist_no_event.determine_definition_hash() != hist_with_event.determine_definition_hash()
@@ -1163,3 +1163,20 @@ def test_determine_aggregations_requires_solved_df(spark):
     )
     with pytest.raises(ValueError, match="requires solved_df"):
         HistogramDuration.determine_aggregations(spark=spark, aggregations=[hist])
+
+
+def test_init_rejects_non_sample_series_base_expr():
+    """base_expr must evaluate to SampleSeries; an Intervals expression is rejected."""
+    with pytest.raises(ValueError, match="SampleSeries"):
+        HistogramDuration(name="bad", base_expr=TimeSeriesSelector(None) > 0, bins=[0.0, 1.0])
+
+
+def test_init_rejects_non_sample_series_weights_expr():
+    """weights_expr must evaluate to SampleSeries; an Intervals expression is rejected."""
+    with pytest.raises(ValueError, match="SampleSeries"):
+        HistogramCustomWeights(
+            name="bad",
+            base_expr=TimeSeriesSelector(None),
+            weights_expr=TimeSeriesSelector(None) > 0,
+            bins=[0.0, 1.0],
+        )

--- a/tests/impulse_reporting/unit/aggregations/stats_aggregator_test.py
+++ b/tests/impulse_reporting/unit/aggregations/stats_aggregator_test.py
@@ -14,7 +14,7 @@ from impulse_reporting.events.basic_event import BasicEvent
 
 def test_as_spark_row():
     """Test that as_spark_row returns a Row with expected fields."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -34,7 +34,7 @@ def test_as_spark_row():
 def test_stats_aggregator_init():
     """Test StatsAggregator initialization with required parameters."""
     input_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -59,7 +59,7 @@ def test_stats_aggregator_init():
 def test_stats_aggregator_init_with_optional_params():
     """Test StatsAggregator initialization with all optional parameters."""
     input_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -87,7 +87,7 @@ def test_stats_aggregator_init_multiple_expressions():
     """Test StatsAggregator initialization with multiple input expressions."""
     input_expr1 = TimeSeriesSelector(None)
     input_expr2 = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -106,7 +106,7 @@ def test_stats_aggregator_init_multiple_expressions():
 def test_stats_aggregator_channel_names_validation():
     """Test that channel_names validation raises error on length mismatch."""
     input_expr = TimeSeriesSelector(None)
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     with pytest.raises(ValueError) as exc_info:
@@ -123,7 +123,7 @@ def test_stats_aggregator_channel_names_validation():
 
 def test_stats_aggregator_empty_expressions_raises():
     """Test that empty input_expressions raises error."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     with pytest.raises(ValueError) as exc_info:
@@ -140,7 +140,7 @@ def test_stats_aggregator_empty_expressions_raises():
 
 def test_get_name():
     """Test get_name method."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -155,7 +155,7 @@ def test_get_name():
 
 def test_get_id():
     """Test get_id returns consistent unique identifier."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -176,7 +176,7 @@ def test_get_id():
 
 def test_get_id_different_for_different_names():
     """Test that get_id returns different values for different names."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg1 = StatsAggregator(
@@ -200,7 +200,7 @@ def test_get_id_different_for_different_names():
 
 def test_get_expression():
     """Test get_expression method returns TimeSeriesExpression."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
     input_expr = TimeSeriesSelector(None)
 
@@ -219,7 +219,7 @@ def test_get_expression():
 
 def test_get_expression_str():
     """Test get_expression_str method."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -237,7 +237,7 @@ def test_get_expression_str():
 
 def test_get_event():
     """Test get_event method returns the associated event."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -254,7 +254,7 @@ def test_get_event():
 
 def test_as_dict():
     """Test as_dict method returns dictionary with expected keys."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -283,7 +283,7 @@ def test_as_dict():
 
 def test_as_dict_multiple_signals():
     """Test as_dict with multiple signals."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -303,7 +303,7 @@ def test_as_dict_multiple_signals():
 
 def test_as_spark_row_complete():
     """Test as_spark_row with all fields populated."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -329,7 +329,7 @@ def test_as_spark_row_complete():
 
 def test_as_spark_row_minimal():
     """Test as_spark_row with minimal required fields."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -351,7 +351,7 @@ def test_as_spark_row_minimal():
 
 def test_statistics_list_validation():
     """Test that statistics parameter accepts different statistic types."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     # Test with various statistics
@@ -611,7 +611,7 @@ def test_stats_aggregator_multiple_input_expressions(spark, basic_narrow_db):
 
 def test_report_id_and_page_number_assignment():
     """Test that report_id and page_number can be assigned."""
-    event_expr = TimeSeriesSelector(None)
+    event_expr = TimeSeriesSelector(None) > 0
     basic_event = BasicEvent(name="test_event", expr=event_expr)
 
     stats_agg = StatsAggregator(
@@ -644,8 +644,19 @@ def test_determine_aggregations_requires_solved_df(spark):
         input_expressions=[TimeSeriesSelector(None)],
         channel_names=["Engine RPM"],
         statistics=["min", "max", "mean"],
-        event=BasicEvent(name="test_event_1", expr=TimeSeriesSelector(None)),
+        event=BasicEvent(name="test_event_1", expr=TimeSeriesSelector(None) > 0),
     )
 
     with pytest.raises(ValueError, match="requires solved_df"):
         StatsAggregator.determine_aggregations(spark=spark, aggregations=[stats_agg])
+
+
+def test_init_rejects_non_sample_series_input():
+    """Input expressions must evaluate to SampleSeries; Intervals must be rejected."""
+    with pytest.raises(ValueError, match="SampleSeries"):
+        StatsAggregator(
+            name="bad_stats",
+            input_expressions=[TimeSeriesSelector(None) > 0],
+            channel_names=["Signal"],
+            statistics=["min"],
+        )

--- a/tests/impulse_reporting/unit/events/basic_event_test.py
+++ b/tests/impulse_reporting/unit/events/basic_event_test.py
@@ -8,7 +8,7 @@ from tests.conftest import basic_narrow_db, spark
 
 def test_as_dict():
     """Test as_dict method"""
-    event = BasicEvent(name="my_event_1", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="my_event_1", expr=(TimeSeriesSelector(None) > 0))
     event_dict = event.as_dict()
     assert isinstance(event_dict, dict)
     assert event_dict.get("event_id") == event.get_id()
@@ -22,20 +22,20 @@ def test_as_dict():
 
 def test_as_spark_row():
     """Test as_spark_row method"""
-    event = BasicEvent(name="my_event_1", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="my_event_1", expr=(TimeSeriesSelector(None) > 0))
     row = event.as_spark_row()
     assert len(row) == 9
 
 
 def test_get_event_type_str():
     """Test get_event_type_str method."""
-    event = BasicEvent(name="my_event", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="my_event", expr=(TimeSeriesSelector(None) > 0))
     assert event.get_event_type_str() == "BASIC_EVENT"
 
 
 def test_basic_event_init():
     """Test BasicEvent initialization with required parameters"""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     event = BasicEvent(name="test_event", expr=expr)
 
     assert event.name == "test_event"
@@ -46,7 +46,7 @@ def test_basic_event_init():
 
 def test_basic_event_init_with_optional_params():
     """Test BasicEvent initialization with all optional parameters"""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
 
     event = BasicEvent(
         name="test_event",
@@ -63,13 +63,13 @@ def test_basic_event_init_with_optional_params():
 
 def test_get_name():
     """Test get_name method"""
-    event = BasicEvent(name="my_event", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="my_event", expr=(TimeSeriesSelector(None) > 0))
     assert event.get_name() == "my_event"
 
 
 def test_get_expression():
     """Test get_expression method returns TimeSeriesExpression"""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     event = BasicEvent(name="test", expr=expr)
     expression = event.get_expression()
     assert expression is not None
@@ -79,7 +79,7 @@ def test_get_expression():
 
 def test_get_expression_str():
     """Test get_expression_str method"""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     event = BasicEvent(name="test", expr=expr)
     expr_str = event.get_expression_str()
     assert isinstance(expr_str, str)
@@ -126,7 +126,7 @@ def test_determine_metadata_df(spark):
     """Test determine_metadata_df method"""
     event = BasicEvent(
         name="test_event",
-        expr=TimeSeriesSelector(None),
+        expr=(TimeSeriesSelector(None) > 0),
         required_channels=["test_signal"],
     )
 
@@ -149,7 +149,7 @@ def test_determine_metadata_df(spark):
 # ---------------------------------------------------------------------------
 def test_definition_hash_exists_in_as_dict():
     """Verify definition_hash key is present and non-null in as_dict output."""
-    event = BasicEvent(name="hash_event", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="hash_event", expr=(TimeSeriesSelector(None) > 0))
     d = event.as_dict()
     assert "definition_hash" in d
     assert d["definition_hash"] is not None
@@ -158,7 +158,7 @@ def test_definition_hash_exists_in_as_dict():
 
 def test_definition_hash_exists_in_spark_row():
     """Verify definition_hash field is present in as_spark_row output."""
-    event = BasicEvent(name="hash_event", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="hash_event", expr=(TimeSeriesSelector(None) > 0))
     row = event.as_spark_row()
     assert hasattr(row, "definition_hash")
     assert row.definition_hash is not None
@@ -167,7 +167,7 @@ def test_definition_hash_exists_in_spark_row():
 
 def test_definition_hash_is_deterministic():
     """Same expression must always produce the same hash."""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     ev1 = BasicEvent(name="ev", expr=expr)
     ev2 = BasicEvent(name="ev", expr=expr)
     assert ev1.determine_definition_hash() == ev2.determine_definition_hash()
@@ -175,7 +175,7 @@ def test_definition_hash_is_deterministic():
 
 def test_definition_hash_ignores_name():
     """Hash must not change when only the name differs."""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     ev1 = BasicEvent(name="name_a", expr=expr)
     ev2 = BasicEvent(name="name_b", expr=expr)
     assert ev1.determine_definition_hash() == ev2.determine_definition_hash()
@@ -183,7 +183,7 @@ def test_definition_hash_ignores_name():
 
 def test_definition_hash_ignores_description():
     """Hash must not change when only desc differs."""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     ev1 = BasicEvent(name="ev", expr=expr, desc="Description A")
     ev2 = BasicEvent(name="ev", expr=expr, desc="Description B")
     assert ev1.determine_definition_hash() == ev2.determine_definition_hash()
@@ -191,13 +191,25 @@ def test_definition_hash_ignores_description():
 
 def test_definition_hash_ignores_required_channels():
     """Hash must not change when only required_channels differs."""
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     ev1 = BasicEvent(name="ev", expr=expr, required_channels=["ch1"])
     ev2 = BasicEvent(name="ev", expr=expr, required_channels=["ch1", "ch2"])
     assert ev1.determine_definition_hash() == ev2.determine_definition_hash()
 
 
 def test_determine_events_requires_solved_df(spark):
-    event = BasicEvent(name="test_event_1", expr=TimeSeriesSelector(None))
+    event = BasicEvent(name="test_event_1", expr=(TimeSeriesSelector(None) > 0))
     with pytest.raises(ValueError, match="requires solved_df"):
         BasicEvent.determine_events(spark, [event])
+
+
+def test_init_rejects_sample_series_expression():
+    """A bare selector evaluates to SampleSeries, not Intervals."""
+    with pytest.raises(ValueError, match="Intervals"):
+        BasicEvent(name="e", expr=TimeSeriesSelector(None))
+
+
+def test_init_rejects_points_in_time_expression():
+    """rising_edges() evaluates to PointsInTime, not Intervals."""
+    with pytest.raises(ValueError, match="Intervals"):
+        BasicEvent(name="e", expr=TimeSeriesSelector(None).rising_edges())

--- a/tests/impulse_reporting/unit/events/definition_hash_test.py
+++ b/tests/impulse_reporting/unit/events/definition_hash_test.py
@@ -9,7 +9,7 @@ class TestBasicEventDefinitionHash:
 
     def test_definition_hash_returns_int(self):
         """Test that determine_definition_hash returns an integer."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
         event = BasicEvent(name="test_event", expr=expr)
 
         hash_value = event.determine_definition_hash()
@@ -17,7 +17,7 @@ class TestBasicEventDefinitionHash:
 
     def test_same_expression_produces_same_hash(self):
         """Test that identical expressions produce the same hash."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
 
         event1 = BasicEvent(name="event_a", expr=expr)
         event2 = BasicEvent(name="event_b", expr=expr)
@@ -27,7 +27,7 @@ class TestBasicEventDefinitionHash:
 
     def test_hash_excludes_name(self):
         """Test that hash doesn't change when only name changes."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
 
         event1 = BasicEvent(name="event_version_1", expr=expr)
         event2 = BasicEvent(name="event_version_2", expr=expr)
@@ -36,7 +36,7 @@ class TestBasicEventDefinitionHash:
 
     def test_hash_excludes_description(self):
         """Test that hash doesn't change when only description changes."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
 
         event1 = BasicEvent(name="test_event", expr=expr, desc="Description v1")
         event2 = BasicEvent(name="test_event", expr=expr, desc="Description v2")
@@ -45,7 +45,7 @@ class TestBasicEventDefinitionHash:
 
     def test_hash_is_consistent_across_instances(self):
         """Test that hash is consistent for same expression across multiple calls."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
         event = BasicEvent(name="test_event", expr=expr)
 
         hash1 = event.determine_definition_hash()
@@ -56,7 +56,7 @@ class TestBasicEventDefinitionHash:
 
     def test_get_id_differs_from_definition_hash(self):
         """Test that get_id and determine_definition_hash produce different values."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
 
         event1 = BasicEvent(name="event_a", expr=expr)
         event2 = BasicEvent(name="event_b", expr=expr)
@@ -69,7 +69,7 @@ class TestBasicEventDefinitionHash:
 
     def test_as_dict_includes_definition_hash(self):
         """Test that as_dict includes the definition_hash field."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
         event = BasicEvent(name="test_event", expr=expr)
 
         result = event.as_dict()
@@ -79,7 +79,7 @@ class TestBasicEventDefinitionHash:
 
     def test_hash_value_within_long_range(self):
         """Test that hash value fits within signed 64-bit long range."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
         event = BasicEvent(name="test_event", expr=expr)
 
         hash_value = event.determine_definition_hash()

--- a/tests/impulse_reporting/unit/events/event_types_test.py
+++ b/tests/impulse_reporting/unit/events/event_types_test.py
@@ -31,6 +31,19 @@ def test_container_event():
     assert result == "event_dimension"
 
 
+def test_points_in_time_event():
+    """POINTS_IN_TIME_EVENT routes to the shared event_instance_fact / event_dimension."""
+    assert EventType.POINTS_IN_TIME_EVENT.get_fact_table_name() == "event_instance_fact"
+    assert EventType.POINTS_IN_TIME_EVENT.get_dimension_table_name() == "event_dimension"
+    assert EventType.POINTS_IN_TIME_EVENT.get_fact_schema().fieldNames() == [
+        "container_id",
+        "event_instance_id",
+        "event_id",
+        "start_ts",
+        "end_ts",
+    ]
+
+
 def test_all_event_type_methods_supported():
     """
     Test that all methods work for all EventType enum values.

--- a/tests/impulse_reporting/unit/events/points_in_time_event_test.py
+++ b/tests/impulse_reporting/unit/events/points_in_time_event_test.py
@@ -1,0 +1,71 @@
+# pylint: disable=missing-function-docstring, redefined-outer-name
+import pyspark.sql.functions as F
+import pytest
+
+from impulse_query_engine.analyze.metadata.time_series_expression import TimeSeriesSelector
+from impulse_query_engine.analyze.query.solvers.default_solver import DefaultSolver
+from impulse_reporting.events.points_in_time_event import PointsInTimeEvent
+from tests.conftest import basic_narrow_db, spark
+
+
+def _points_expr():
+    """A bare expression that evaluates to PointsInTime (no Spark needed)."""
+    return TimeSeriesSelector(None).rising_edges()
+
+
+def test_as_dict():
+    event = PointsInTimeEvent(name="my_event_1", expr=_points_expr())
+    d = event.as_dict()
+    assert d.get("event_type") == "POINTS_IN_TIME_EVENT"
+    assert d.get("event_name") == "my_event_1"
+    assert d.get("event_id") == event.get_id()
+    assert d.get("report_id") == -1
+
+
+def test_get_event_type_str():
+    event = PointsInTimeEvent(name="e", expr=_points_expr())
+    assert event.get_event_type_str() == "POINTS_IN_TIME_EVENT"
+
+
+def test_as_spark_row():
+    row = PointsInTimeEvent(name="e", expr=_points_expr()).as_spark_row()
+    assert len(row) == 9
+    assert row.event_type == "POINTS_IN_TIME_EVENT"
+
+
+def test_definition_hash_ignores_name():
+    e1 = PointsInTimeEvent(name="name_a", expr=_points_expr())
+    e2 = PointsInTimeEvent(name="name_b", expr=_points_expr())
+    assert e1.determine_definition_hash() == e2.determine_definition_hash()
+
+
+def test_init_rejects_intervals_expression():
+    with pytest.raises(ValueError, match="PointsInTime"):
+        PointsInTimeEvent(name="e", expr=TimeSeriesSelector(None) > 0)
+
+
+def test_init_rejects_sample_series_expression():
+    with pytest.raises(ValueError, match="PointsInTime"):
+        PointsInTimeEvent(name="e", expr=TimeSeriesSelector(None))
+
+
+def test_determine_events(spark, basic_narrow_db):
+    eng_rpm = basic_narrow_db.query.channel(channel_name="Engine RPM")
+    event = PointsInTimeEvent(name="rpm_rising", expr=eng_rpm.rising_edges())
+
+    solver = DefaultSolver(spark)
+    solved_df = basic_narrow_db.query.select(event.get_expression()).solve(spark, solver)
+    df = PointsInTimeEvent.determine_events(spark, [event], solved_df=solved_df)
+
+    assert {"container_id", "event_instance_id", "event_id", "start_ts", "end_ts"}.issubset(
+        set(df.columns)
+    )
+    assert df.count() > 0
+    # every instance is a zero-duration point
+    assert df.filter(F.col("start_ts") != F.col("end_ts")).count() == 0
+
+
+def test_determine_events_requires_solved_df(spark):
+    event = PointsInTimeEvent(name="e", expr=_points_expr())
+    with pytest.raises(ValueError, match="requires solved_df"):
+        PointsInTimeEvent.determine_events(spark, [event])

--- a/tests/impulse_reporting/unit/events/sequence_of_events_test.py
+++ b/tests/impulse_reporting/unit/events/sequence_of_events_test.py
@@ -11,7 +11,7 @@ def test_sequence_of_events_init():
     """Test SequenceOfEvents initialization with required parameters."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
 
     assert event.name == "test_soe"
@@ -25,7 +25,7 @@ def test_sequence_of_events_init_with_optional_params():
     """Test SequenceOfEvents initialization with optional parameters."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
         desc="desc",
         required_channels=["ch1"],
     )
@@ -41,7 +41,7 @@ def test_get_name():
     """Test get_name method."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     assert event.get_name() == "test_soe"
 
@@ -50,15 +50,15 @@ def test_get_id():
     """Test get_id method determinism and differentiation by name."""
     event1 = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     event2 = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     event3 = SequenceOfEvents(
         name="test_soe_2",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
 
     assert event1.get_id() == event2.get_id()
@@ -69,7 +69,7 @@ def test_get_expression():
     """Test get_expression method returns TimeSeriesExpression."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     expression = event.get_expression()
     assert expression is not None
@@ -80,7 +80,7 @@ def test_get_expression_str():
     """Test get_expression_str method."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     expr_str = event.get_expression_str()
     assert isinstance(expr_str, str)
@@ -91,7 +91,7 @@ def test_as_dict():
     """Test as_dict method."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     event_dict = event.as_dict()
 
@@ -109,7 +109,7 @@ def test_as_spark_row():
     """Test as_spark_row method."""
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     row = event.as_spark_row()
     assert len(row) == 9  # Should have 9 fields as defined in the schema
@@ -119,11 +119,11 @@ def test_determine_metadata_df(spark):
     """Test determine_metadata_df method."""
     event1 = SequenceOfEvents(
         name="test_soe_1",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     event2 = SequenceOfEvents(
         name="test_soe_2",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
 
     metadata_df = SequenceOfEvents.determine_metadata_df(spark, [event1, event2])
@@ -170,7 +170,16 @@ def test_determine_events(spark, basic_narrow_db):
 def test_determine_events_requires_solved_df(spark):
     event = SequenceOfEvents(
         name="test_soe",
-        expressions=[TimeSeriesSelector(None), TimeSeriesSelector(None)],
+        expressions=[(TimeSeriesSelector(None) > 0), (TimeSeriesSelector(None) > 0)],
     )
     with pytest.raises(ValueError, match="requires solved_df"):
         SequenceOfEvents.determine_events(spark, [event])
+
+
+def test_init_rejects_non_intervals_expression():
+    """Each expression must evaluate to Intervals; a bare selector is SampleSeries."""
+    with pytest.raises(ValueError, match="Intervals"):
+        SequenceOfEvents(
+            name="test_soe",
+            expressions=[(TimeSeriesSelector(None) > 0), TimeSeriesSelector(None)],
+        )

--- a/tests/impulse_reporting/unit/events/test_basic_event_attributes.py
+++ b/tests/impulse_reporting/unit/events/test_basic_event_attributes.py
@@ -13,32 +13,32 @@ class TestBasicEventAttributes:
 
     def test_default_attributes_is_empty_dict(self):
         """BasicEvent without attributes kwarg should default to {}."""
-        event = BasicEvent(name="e", expr=TimeSeriesSelector(None))
+        event = BasicEvent(name="e", expr=(TimeSeriesSelector(None) > 0))
         assert event.attributes == {}
 
     def test_custom_attributes(self):
         """BasicEvent with explicit attributes should store them."""
         attrs = {"limit_type": "warning", "limit_direction": "lower"}
-        event = BasicEvent(name="e", expr=TimeSeriesSelector(None), attributes=attrs)
+        event = BasicEvent(name="e", expr=(TimeSeriesSelector(None) > 0), attributes=attrs)
         assert event.attributes == attrs
 
     def test_as_dict_includes_attributes(self):
         """as_dict must include the 'attributes' key with correct value."""
         attrs = {"limit_type": "error"}
-        event = BasicEvent(name="e", expr=TimeSeriesSelector(None), attributes=attrs)
+        event = BasicEvent(name="e", expr=(TimeSeriesSelector(None) > 0), attributes=attrs)
         d = event.as_dict()
         assert "attributes" in d
         assert d["attributes"] == attrs
 
     def test_as_dict_default_attributes(self):
         """as_dict must include attributes == {} when none are provided."""
-        event = BasicEvent(name="e", expr=TimeSeriesSelector(None))
+        event = BasicEvent(name="e", expr=(TimeSeriesSelector(None) > 0))
         d = event.as_dict()
         assert d["attributes"] == {}
 
     def test_definition_hash_excludes_attributes(self):
         """Changing attributes must not change the definition hash."""
-        expr = TimeSeriesSelector(None)
+        expr = TimeSeriesSelector(None) > 0
         ev1 = BasicEvent(name="e", expr=expr, attributes={"limit_type": "warning"})
         ev2 = BasicEvent(name="e", expr=expr, attributes={"limit_type": "error"})
         ev3 = BasicEvent(name="e", expr=expr)
@@ -50,7 +50,7 @@ class TestBasicEventAttributes:
         """as_spark_row must include an 'attributes' field."""
         event = BasicEvent(
             name="e",
-            expr=TimeSeriesSelector(None),
+            expr=(TimeSeriesSelector(None) > 0),
             attributes={"k": "v"},
         )
         row = event.as_spark_row()
@@ -59,13 +59,13 @@ class TestBasicEventAttributes:
 
     def test_as_spark_row_field_count(self):
         """Spark row must have 9 fields matching EVENT_DIMENSION_SCHEMA."""
-        event = BasicEvent(name="e", expr=TimeSeriesSelector(None))
+        event = BasicEvent(name="e", expr=(TimeSeriesSelector(None) > 0))
         row = event.as_spark_row()
         assert len(row) == len(EVENT_DIMENSION_SCHEMA.fields)
 
     def test_none_attributes_becomes_empty_dict(self):
         """Passing attributes=None should be treated as {}."""
-        event = BasicEvent(name="e", expr=TimeSeriesSelector(None), attributes=None)
+        event = BasicEvent(name="e", expr=(TimeSeriesSelector(None) > 0), attributes=None)
         assert event.attributes == {}
 
 

--- a/tests/impulse_reporting/unit/incremental/definition_hash_comparator_test.py
+++ b/tests/impulse_reporting/unit/incremental/definition_hash_comparator_test.py
@@ -27,7 +27,7 @@ def test_empty_events_list_returns_empty_tuples(spark):
 def test_all_events_changed_when_table_does_not_exist(spark):
     """Test that all events are marked as changed when gold table doesn't exist."""
     comparator = DefinitionHashComparator(spark)
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     events = [
         BasicEvent(name="event_1", expr=expr),
         BasicEvent(name="event_2", expr=expr),
@@ -48,7 +48,7 @@ def test_all_events_changed_when_table_does_not_exist(spark):
 def test_new_event_is_marked_as_changed(spark):
     """Test that a new event not in gold table is marked as changed."""
     comparator = DefinitionHashComparator(spark)
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
 
     # Create an event
     new_event = BasicEvent(name="new_event", expr=expr)
@@ -80,7 +80,7 @@ def test_new_event_is_marked_as_changed(spark):
 def test_unchanged_event_with_matching_hash(spark):
     """Test that event with matching hash is marked as unchanged."""
     comparator = DefinitionHashComparator(spark)
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     event = BasicEvent(name="test_event", expr=expr)
 
     # Create dimension table with matching hash
@@ -110,7 +110,7 @@ def test_unchanged_event_with_matching_hash(spark):
 def test_changed_event_with_different_hash(spark):
     """Test that event with different hash is marked as changed."""
     comparator = DefinitionHashComparator(spark)
-    expr = TimeSeriesSelector(None)
+    expr = TimeSeriesSelector(None) > 0
     event = BasicEvent(name="test_event", expr=expr)
 
     # Create dimension table with different hash (simulating definition change)


### PR DESCRIPTION
## Summary

- Introduced the PointsInTimeEvent class to represent events derived from TSAL expressions evaluating to PointsInTime, generating zero-duration event instances.
- Updated event output schema to include POINTS_IN_TIME_EVENT type and modified event type handling in the EventType enum.
- Enhanced documentation for PointsInTimeEvent, detailing its functionality and usage examples.
- Added integration and unit tests to validate the behavior of PointsInTimeEvent, ensuring correct persistence and event instance generation.
- Implemented evaluation type method in TimeSeriesExpression to support type validation for all Events and Aggregations.

## Changes

- 

## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Documentation updated (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new linter warnings introduced
