### PR TITLE
Add start_points and end_points methods to Intervals class

### DIFF
--- a/docs/impulse/docs/references/api/impulse_query_engine/model/series/intervals.md
+++ b/docs/impulse/docs/references/api/impulse_query_engine/model/series/intervals.md
@@ -171,6 +171,30 @@ Returns an array of all end times.
 
 `numpy.ndarray`: Array of interval end times.
 
+#### start\_points
+
+```python
+def start_points() -> PointsInTime
+```
+
+Returns the start time of each interval as a PointsInTime.
+
+**Returns**:
+
+`PointsInTime`: Points in time, one at the start of each interval.
+
+#### end\_points
+
+```python
+def end_points() -> PointsInTime
+```
+
+Returns the end time of each interval as a PointsInTime.
+
+**Returns**:
+
+`PointsInTime`: Points in time, one at the end of each interval.
+
 #### start\_time
 
 ```python

--- a/docs/impulse/docs/references/query_engine/tsal/core_data_model.md
+++ b/docs/impulse/docs/references/query_engine/tsal/core_data_model.md
@@ -34,6 +34,7 @@ graph LR
   SS -->|"where(PointsInTime)"| PITS["PointsInTimeSeries"]
   SS -->|"min / max / mean / sum"| SC(["scalar"])
   IV -->|"intersect with PointsInTime"| PIT
+  IV -->|"start / end points"| PIT
   PIT -->|expand| IV
   PITS -->|compare| PIT
   PITS -->|"min / max / mean / sum"| SC
@@ -86,7 +87,8 @@ eng_rpm > 2000          # Intervals: every window where RPM exceeds 2000
 
 Key operations: `&` (intersection), `|` (union), `expand()` / `shrink()` (grow or contract window
 bounds), `merge_overlaps()` / `merge_intervals(gap)`, `debounce(d)`, and `filter(d)` (drop windows
-shorter than `d`). Intersecting `Intervals` with a `PointsInTime` keeps only the points that fall
+shorter than `d`). `start_points()` / `end_points()` turn the window boundaries into a
+`PointsInTime`. Intersecting `Intervals` with a `PointsInTime` keeps only the points that fall
 inside a window and returns a `PointsInTime`.
 
 → API: [`Intervals`](../../api/impulse_query_engine/model/series/intervals.md)
@@ -155,6 +157,7 @@ Operations move between the four classes (and scalars) in well-defined ways:
 | `SampleSeries`       | `sum()` / `min()` / `max()` / `mean()`         | scalar               |
 | `Intervals`          | `&` / `\|`                                     | `Intervals`          |
 | `Intervals`          | `& PointsInTime`                               | `PointsInTime`       |
+| `Intervals`          | `start_points()` / `end_points()`              | `PointsInTime`       |
 | `PointsInTime`       | `expand()` / `expand_left()` / `expand_right()`| `Intervals`          |
 | `PointsInTimeSeries` | `> >= < <= == !=`                              | `PointsInTime`       |
 | `PointsInTimeSeries` | `+ - * /`                                      | `PointsInTimeSeries` |

--- a/src/impulse_query_engine/model/series/intervals.py
+++ b/src/impulse_query_engine/model/series/intervals.py
@@ -254,6 +254,28 @@ class Intervals:
         """
         return self.tends
 
+    def start_points(self) -> PointsInTime:
+        """
+        Returns the start time of each interval as a PointsInTime.
+
+        Returns
+        -------
+        PointsInTime
+            Points in time, one at the start of each interval.
+        """
+        return PointsInTime(self.tstarts)
+
+    def end_points(self) -> PointsInTime:
+        """
+        Returns the end time of each interval as a PointsInTime.
+
+        Returns
+        -------
+        PointsInTime
+            Points in time, one at the end of each interval.
+        """
+        return PointsInTime(self.tends)
+
     def start_time(self) -> np.float64:
         """
         Returns the start time of the first interval.

--- a/tests/impulse_query_engine/integration/points_in_time_series_solve_test.py
+++ b/tests/impulse_query_engine/integration/points_in_time_series_solve_test.py
@@ -49,6 +49,40 @@ def test_where_rising_edges_solves_to_points_in_time_series(spark, basic_narrow_
     assert saw_non_empty  # Engine RPM has rising edges in the test data
 
 
+def test_interval_start_and_end_points_solve_to_points_in_time(spark, basic_narrow_db):
+    """Solving (channel > x).start_points() / .end_points() yields PointsInTime columns whose
+    values are exactly the start / end boundary of each comparison window, end to end."""
+    query = basic_narrow_db.query
+    eng_rpm = query.channel(channel_name="Engine RPM")
+
+    # "windows" is the Intervals where the engine is running; "starts"/"ends" are the
+    # PointsInTime at those windows' boundaries.
+    result = query.select(
+        (eng_rpm > 0).alias("windows"),  # array<array<double>>  [[s, e], ...]
+        (eng_rpm > 0).start_points().alias("starts"),  # array<double>  [s, ...]
+        (eng_rpm > 0).end_points().alias("ends"),  # array<double>  [e, ...]
+    ).solve(spark, solver=DefaultSolver(spark))
+
+    # array-storage representation, verified end to end
+    assert result.schema["windows"].dataType == T.ArrayType(T.ArrayType(T.DoubleType()))
+    assert result.schema["starts"].dataType == T.ArrayType(T.DoubleType())
+    assert result.schema["ends"].dataType == T.ArrayType(T.DoubleType())
+
+    rows = result.collect()
+    assert {row.container_id for row in rows} == {1, 2, 3}
+
+    saw_non_empty = False
+    for row in rows:
+        windows = row["windows"]  # [[s, e], ...]
+        # start_points / end_points are exactly the boundaries of each window
+        assert list(row["starts"]) == [w[0] for w in windows]
+        assert list(row["ends"]) == [w[1] for w in windows]
+        if windows:
+            saw_non_empty = True
+
+    assert saw_non_empty  # Engine RPM is > 0 somewhere in the test data
+
+
 def test_points_in_time_series_round_trips_via_to_pandas(spark, basic_narrow_db):
     """toPandas returns the raw array representation (no deserialization to an object)."""
     query = basic_narrow_db.query

--- a/tests/impulse_query_engine/unit/model/series/intervals_test.py
+++ b/tests/impulse_query_engine/unit/model/series/intervals_test.py
@@ -91,6 +91,34 @@ def test_ends():
     nptest.assert_array_equal([0, 1], intvls.starts())
 
 
+def test_start_points_empty():
+    intvls = Intervals.empty()
+    result = intvls.start_points()
+    assert isinstance(result, PointsInTime)
+    assert len(result) == 0
+
+
+def test_start_points():
+    intvls = Intervals([0, 1], [1, 2])
+    result = intvls.start_points()
+    assert isinstance(result, PointsInTime)
+    nptest.assert_array_equal([0, 1], result.tstarts)
+
+
+def test_end_points_empty():
+    intvls = Intervals.empty()
+    result = intvls.end_points()
+    assert isinstance(result, PointsInTime)
+    assert len(result) == 0
+
+
+def test_end_points():
+    intvls = Intervals([0, 1], [1, 2])
+    result = intvls.end_points()
+    assert isinstance(result, PointsInTime)
+    nptest.assert_array_equal([1, 2], result.tstarts)
+
+
 def test_start_time_empty():
     intvls = Intervals.empty()
     assert np.isnan(intvls.start_time())
@@ -1013,3 +1041,35 @@ def test_plane_sweep_intervals_and_points_in_time():
     result = Intervals.plane_sweep(intervals1, points_in_time)
     expected = [(0, 0), (1, 1), (2, 2)]
     assert result == expected
+
+
+def test_timeseries_op_start_points(mocker):
+    """
+    (EngSpd > 2000).start_points() builds to a PointsInTime at each window start.
+
+    EngSpd > 2000 yields windows [1, 3), [5, 7), [8, 9); their starts are [1, 5, 8].
+    """
+    eng_spd = TimeSeriesSelector(TagSelector("channel_name") == "EngSpd")
+    expr = (eng_spd > 2000).start_points()
+
+    cache = _make_cache(mocker, _eng_spd_series())
+    result = expr.build(cache)
+
+    assert isinstance(result, PointsInTime)
+    nptest.assert_array_equal([1, 5, 8], result.tstarts)
+
+
+def test_timeseries_op_end_points(mocker):
+    """
+    (EngSpd > 2000).end_points() builds to a PointsInTime at each window end.
+
+    EngSpd > 2000 yields windows [1, 3), [5, 7), [8, 9); their ends are [3, 7, 9].
+    """
+    eng_spd = TimeSeriesSelector(TagSelector("channel_name") == "EngSpd")
+    expr = (eng_spd > 2000).end_points()
+
+    cache = _make_cache(mocker, _eng_spd_series())
+    result = expr.build(cache)
+
+    assert isinstance(result, PointsInTime)
+    nptest.assert_array_equal([3, 7, 9], result.tstarts)


### PR DESCRIPTION
## Summary

- Implemented start_points() and end_points() methods in the Intervals class to return the start and end times of intervals as PointsInTime.
- Updated documentation to include descriptions and return types for the new methods.
- Added unit tests to validate the functionality of start_points() and end_points(), ensuring correct behavior for both empty and populated intervals.
- Enhanced related documentation to reflect the new methods and their usage in the context of PointsInTime.

## Changes

- 

## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Documentation updated (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new linter warnings introduced
