### PR TITLE
CI: split test job into parallel query-engine and reporting shards

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -16,6 +16,20 @@ coverage:
         target: auto
         threshold: 0.5%
 
+# The test suite is sharded by component across parallel CI jobs; each shard uploads
+# coverage under its own flag. carryforward keeps a flag's last coverage on commits
+# where only the other shard ran. The project/patch statuses above operate on the merged total.
+flag_management:
+  default_rules:
+    carryforward: true
+flags:
+  query_engine:
+    paths:
+      - src/impulse_query_engine/
+  reporting:
+    paths:
+      - src/impulse_reporting/
+
 comment:                  # this is a top-level key
   layout: "diff, flags, files"
   behavior: default

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -56,7 +56,7 @@ jobs:
         run: make lint
 
   test:
-    name: Testing
+    name: Testing (${{ matrix.component }})
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -64,8 +64,13 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ '3.12' ]
+        include:
+          - component: query_engine
+            path: tests/impulse_query_engine
+          - component: reporting
+            path: tests/impulse_reporting
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -90,10 +95,10 @@ jobs:
         run: make dev
 
       - name: Run unit tests with coverage
-        run: make test
+        run: make test TEST_PATH=${{ matrix.path }}
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           use_oidc: true
+          flags: ${{ matrix.component }}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ export UV_BUILD_CONSTRAINT := .build-constraints.txt
 
 UV_RUN := uv run --exact --all-extras
 
+# Path(s) passed to pytest. Defaults to the whole suite; CI overrides this to run a
+# single component's tests in parallel, e.g. `make test TEST_PATH=tests/impulse_query_engine`.
+TEST_PATH ?= tests/
+
 clean:
 	rm -fr .venv htmlcov .pytest_cache .ruff_cache .coverage coverage.xml test-results.xml
 	find . -name '__pycache__' -print0 | xargs -0 rm -fr
@@ -28,7 +32,7 @@ fmt:
 	$(UV_RUN) ruff check src/ tests/ --fix
 
 test:
-	$(UV_RUN) pytest tests/ --cov=src --cov-branch --cov-report=xml
+	$(UV_RUN) pytest $(TEST_PATH) --cov=src --cov-branch --cov-report=xml
 
 coverage:
 	$(UV_RUN) pytest tests/ --cov=src --cov-branch --cov-report=html


### PR DESCRIPTION
## Summary

Splits the single `test` job in acceptance.yml into a parallel matrix over
`component: [query_engine, reporting]`, so the two halves of the suite run
concurrently on separate runners instead of back-to-back. The shared
`not-a-fork` → `lint` gate is unchanged.

- **Makefile**: `test` target takes an optional `TEST_PATH` (defaults to
  `tests/`); CI passes each component's path. Coverage still measured against
  all of `src/`.
- **acceptance.yml**: `test` becomes a `fail-fast: false` matrix; each shard
  uploads coverage under a Codecov `flag`. Replaces the old single-value
  `python-version` matrix.
- **codecov.yml**: declares `query_engine` / `reporting` flags with
  `carryforward` so per-shard uploads merge into the combined total.

Verified the partition is exact (780 + 598 = 1378 tests, no overlap) and that
a sharded `make test` still emits `coverage.xml`.

## Test Plan

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Documentation updated (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No new linter warnings introduced
