### PR TITLE
Add optional calculated_channel_metrics table with configurable KPIs

### DIFF
--- a/demos/reporting_pipeline.ipynb
+++ b/demos/reporting_pipeline.ipynb
@@ -94,12 +94,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793606275,
      "inputWidgets": {},
      "nuid": "3a9e5503-3ba0-461a-a80b-116786825131",
      "showTitle": false,
-     "startTime": 1781793599974,
-     "submitTime": 1781793599633,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -141,12 +138,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793606499,
      "inputWidgets": {},
      "nuid": "e6b082aa-cd90-4404-8d01-c4def6fba1d0",
      "showTitle": false,
-     "startTime": 1781793606289,
-     "submitTime": 1781793599651,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -170,12 +164,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793606692,
      "inputWidgets": {},
      "nuid": "e10f7a71-bced-4bd8-944a-e849514810dc",
      "showTitle": false,
-     "startTime": 1781793606538,
-     "submitTime": 1781793599653,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -251,12 +242,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793641047,
      "inputWidgets": {},
      "nuid": "852c8b37-8b00-416a-9caf-508562963ed6",
      "showTitle": false,
-     "startTime": 1781793606709,
-     "submitTime": 1781793599671,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -295,12 +283,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793642921,
      "inputWidgets": {},
      "nuid": "d4ffcc59-1e8d-46bf-9f87-050786d77ae5",
      "showTitle": false,
-     "startTime": 1781793641071,
-     "submitTime": 1781793599674,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -319,12 +304,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793644622,
      "inputWidgets": {},
      "nuid": "7659474f-f00e-4577-aa28-133387922e28",
      "showTitle": false,
-     "startTime": 1781793642933,
-     "submitTime": 1781793599677,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -381,12 +363,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793647268,
      "inputWidgets": {},
      "nuid": "90785aab-526e-4afd-8156-cef0bb28b142",
      "showTitle": false,
-     "startTime": 1781793644642,
-     "submitTime": 1781793599698,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -428,6 +407,11 @@
     "        \"container_id\", \"vehicle_key\",\n",
     "        \"start_ts\", \"stop_ts\",\n",
     "    ],\n",
+    "    \"calculated_channels\": {\n",
+    "        \"emit_channel_metrics\": True,\n",
+    "        \"attribute_columns\": [],\n",
+    "        \"kpis\": [\"duration\", \"min\", \"max\", \"mean\"],\n",
+    "    },\n",
     "}\n",
     "\n",
     "report = Report(\n",
@@ -470,12 +454,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793647472,
      "inputWidgets": {},
      "nuid": "8f9aebe1-97ec-417e-9072-e859eed8b86f",
      "showTitle": false,
-     "startTime": 1781793647280,
-     "submitTime": 1781793599806,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -534,12 +515,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793647669,
      "inputWidgets": {},
      "nuid": "6e4fa193-a588-4bea-8849-abcc89aaac36",
      "showTitle": false,
-     "startTime": 1781793647482,
-     "submitTime": 1781793599821,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -594,12 +572,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793647872,
      "inputWidgets": {},
      "nuid": "1bc57151-3988-4458-afef-fa258e8b74f8",
      "showTitle": false,
-     "startTime": 1781793647688,
-     "submitTime": 1781793599839,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -668,12 +643,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793648182,
      "inputWidgets": {},
      "nuid": "4c31ea1c-64d0-4383-88bb-e363b2881d2c",
      "showTitle": false,
-     "startTime": 1781793647893,
-     "submitTime": 1781793599855,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -752,6 +724,36 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "41b9398e-6cc2-44e7-9320-0b47d55536a9",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "Register Calculated Channel"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from impulse_reporting.channels.calculated_channel import CalculatedChannel\n",
+    "\n",
+    "avg_temp_channel = CalculatedChannel(\n",
+    "    name=\"avg_temp\",\n",
+    "    expr=avg_temp,\n",
+    "    identity={\"channel_name\": \"avg_temp\", \"data_key\": \"CALC\"},\n",
+    "    desc=\"Average of ambient and intake air temperature\",\n",
+    ")\n",
+    "report.add_calculated_channel(avg_temp_channel)\n",
+    "print(\"Calculated channel 'avg_temp' registered\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "application/vnd.databricks.v1+cell": {
@@ -782,12 +784,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793726278,
      "inputWidgets": {},
      "nuid": "57dc4f62-2518-46b7-b418-7e3a9090860a",
      "showTitle": false,
-     "startTime": 1781793648214,
-     "submitTime": 1781793599870,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -836,12 +835,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793733571,
      "inputWidgets": {},
      "nuid": "e8bc4484-f84a-45d7-b848-d9d17293e688",
      "showTitle": true,
-     "startTime": 1781793726299,
-     "submitTime": 1781793599888,
      "tableResultSettingsMap": {},
      "title": "Visualize Gold Layer Results"
     }
@@ -1016,12 +1012,9 @@
       "byteLimit": 2048000,
       "rowLimit": 10000
      },
-     "finishTime": 1781793733685,
      "inputWidgets": {},
      "nuid": "e71e2dd7-afdc-4468-a09f-ef0f94094a79",
      "showTitle": false,
-     "startTime": 1781793733585,
-     "submitTime": 1781793599907,
      "tableResultSettingsMap": {},
      "title": ""
     }
@@ -1144,7 +1137,7 @@
      }
     },
     "schema": {
-     "currentValue": "default",
+     "currentValue": "thomas_bonfert",
      "nuid": "6970e201-5950-4033-9f3c-54c0d3ba354f",
      "typedWidgetInfo": {
       "autoCreated": false,

--- a/docs/impulse/docs/config/configuration.md
+++ b/docs/impulse/docs/config/configuration.md
@@ -352,6 +352,40 @@ mode-resolution rules and what counts as a definition change.
 
 ---
 
+## calculated_channels (optional)
+
+Controls the optional `calculated_channel_metrics` output. By default a report
+writes calculated channels to `calculated_channel_fact` (the derived signal) and
+`calculated_channel_dimension` (the definitions). Setting `emit_channel_metrics`
+adds a third table, `calculated_channel_metrics`, shaped like the silver
+`channel_metrics` table so the fact + metrics pair can serve as an Impulse silver
+source. See the [Channels reference](../references/report/channel.md) for the
+output schema.
+
+| Field                 | Type        | Default                              | Description                                                                                       |
+|-----------------------|-------------|--------------------------------------|---------------------------------------------------------------------------------------------------|
+| `emit_channel_metrics`| `bool`      | `false`                              | Turns on the `calculated_channel_metrics` table.                                                  |
+| `attribute_columns`   | `list[str]` | `[]`                                 | Calculated-channel `attributes` keys to surface as columns on the metrics table (e.g. `["unit"]`). |
+| `kpis`                | `list[str]` | `["duration", "min", "max", "mean"]` | KPIs computed per `(container_id, channel_id)`, one column each. Must be registered KPI names.     |
+
+When enabled, each row of `calculated_channel_metrics` is one
+`(container_id, channel_id)` pair, carrying the selected `kpis` plus dynamic
+identity columns (the union of `identity` keys across the report's channels) and
+the configured `attribute_columns`. A channel that omits an identity or attribute
+key gets `null` for that column; an identity key wins over an attribute key of the
+same name.
+
+The available `kpis` are `duration`, `min`, `max`, and `mean` (all
+duration-weighted, matching the silver ingestion semantics). An unknown KPI name is
+rejected at config validation with a `ValueError` naming the valid KPIs.
+
+:::note Off by default
+When `emit_channel_metrics` is `false` (the default), no metrics table is written
+and `attribute_columns` / `kpis` have no effect.
+:::
+
+---
+
 ## measurement_dimensions (optional)
 
 List of `container_metrics` column names to surface into the gold-layer

--- a/docs/impulse/docs/data_model/gold_layer_event_normalized.md
+++ b/docs/impulse/docs/data_model/gold_layer_event_normalized.md
@@ -186,6 +186,18 @@ calculated_channel_fact {
     timestamp _created_at
 }
 
+calculated_channel_metrics {
+    int container_id
+    long channel_id
+    string type
+    string data_type
+    double duration
+    double min
+    double max
+    double mean
+    timestamp _created_at
+}
+
 histogram_fact }o--|| event_dimension: event_id
 histogram2d_fact }o--|| event_dimension: event_id
 stats_aggregator_fact }o--|| event_instance_fact: event_instance_id
@@ -221,7 +233,8 @@ guaranteed.
 | `{prefix}_histogram2d_fact`      | `container_id`, `visual_id`, `event_id`, `x_bin_id`, `y_bin_id`                        | 2D histogram bin values per container.                       |
 | `{prefix}_stats_aggregator_fact` | `container_id`, `visual_id`, `event_instance_id`, `channel_name`, `aggregation_label`  | Statistics values per signal, event instance, and container. |
 | `{prefix}_event_instance_fact`   | `container_id`, `event_id`, `event_instance_id`                                        | Materialized event occurrences with start/end timestamps.    |
-| `{prefix}_calculated_channel_fact` | `container_id`, `channel_id`, `tstart`                                               | Materialized derived signal — one row per sample interval, in the silver `channels` shape (`tstart`, `tend`, `value`). The channel's identity lives on `calculated_channel_dimension`, joined via `channel_id`. |
+| `{prefix}_calculated_channel_fact` | `container_id`, `channel_id`, `tstart`                                               | Materialized derived signal, one row per sample interval, in the silver `channels` shape (`tstart`, `tend`, `value`). The channel's identity lives on `calculated_channel_dimension`, joined via `channel_id`. |
+| `{prefix}_calculated_channel_metrics` | `container_id`, `channel_id`                                                       | Optional per-channel metrics in the silver `channel_metrics` shape, so the fact + metrics pair can serve as an Impulse silver source. Written only when [`config.calculated_channels.emit_channel_metrics`](../config/configuration.md#calculated_channels-optional) is set. Carries the configured `kpis` plus dynamic identity/attribute columns. See [Channels](../references/report/channel.md). |
 
 ---
 

--- a/docs/impulse/docs/data_model/gold_layer_event_normalized.md
+++ b/docs/impulse/docs/data_model/gold_layer_event_normalized.md
@@ -189,7 +189,7 @@ calculated_channel_fact {
 calculated_channel_metrics {
     int container_id
     long channel_id
-    string data_type
+    string value_type
     double duration
     double min
     double max

--- a/docs/impulse/docs/data_model/gold_layer_event_normalized.md
+++ b/docs/impulse/docs/data_model/gold_layer_event_normalized.md
@@ -189,7 +189,6 @@ calculated_channel_fact {
 calculated_channel_metrics {
     int container_id
     long channel_id
-    string type
     string data_type
     double duration
     double min

--- a/docs/impulse/docs/data_model/index.md
+++ b/docs/impulse/docs/data_model/index.md
@@ -62,6 +62,7 @@ The Gold layer uses a **star schema** with fact and dimension tables. All table 
 | `histogram2d_fact`     | One row per (x, y) bin per container     | 2D histogram bin values, duration-weighted.               |
 | `stats_aggregator_fact` | One row per statistic label per signal per event instance | Descriptive statistics (built-in min/max/mean/median and any custom statistics). |
 | `calculated_channel_fact` | One row per sample interval per container | Materialized derived signal (a *channel*, not a summary), in the silver `channels` shape. |
+| `calculated_channel_metrics` | One row per calculated channel per container | Optional per-channel metrics in the silver `channel_metrics` shape. Written only when `config.calculated_channels.emit_channel_metrics` is set. |
 
 ### Dimension tables
 

--- a/docs/impulse/docs/references/api/impulse_query_engine/analyze/query/aggregations/statistic_type.md
+++ b/docs/impulse/docs/references/api/impulse_query_engine/analyze/query/aggregations/statistic_type.md
@@ -20,4 +20,6 @@ Enumeration of supported statistic types for aggregations.
 - `MAX` (`str`): Maximum value statistic.
 - `MEAN` (`str`): Mean (average) value statistic.
 - `MEDIAN` (`str`): Median value statistic.
+- `START` (`str`): First value in the interval.
+- `END` (`str`): Last value in the interval.
 

--- a/docs/impulse/docs/references/api/impulse_reporting/aggregations/stats_aggregator.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/aggregations/stats_aggregator.md
@@ -190,14 +190,16 @@ Only includes computation-affecting attributes:
 - input_expressions
 - statistics to be calculated
 - event expression if there is any
-- custom statistics (name, kind, declared input indices, and function
-  bytecode, so implementation or input-wiring changes invalidate cached
-  results; only appended when custom statistics are configured so
-  aggregators without them keep their previous hash)
+- channel_names, and each cross-channel descriptor's channel_name. These
+  are the fact table's ``channel_name`` merge key, so a rename must force
+  a recompute (a changed definition recomputes and prunes all containers);
+  otherwise, in incremental mode, already-processed containers would keep
+  rows under the old name.
+- custom statistics (labels, kind, declared input indices, params, and
+  function bytecode, so implementation or input-wiring changes invalidate
+  cached results; only appended when custom statistics are configured)
 
-Excludes: name, desc, signal_name, units, page_number, report_id, and the
-cross-channel descriptors' channel_name (presentation metadata, like
-channel_names).
+Excludes: name, desc, units, page_number, report_id.
 
 **Returns**:
 

--- a/docs/impulse/docs/references/api/impulse_reporting/channels/calculated_channel.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/channels/calculated_channel.md
@@ -200,9 +200,9 @@ narrow fact rows** (``container_id, channel_id, tstart, tend, value``),
 grouped by ``(container_id, channel_id)``.
 
 The output schema is **dynamic**: fixed columns ``container_id,
-channel_id, type, data_type`` plus one column per configured KPI (see
-``kpis``), one per identity key (the union across all ``channels``), and one
-per configured attribute key.  Identity/attribute values are pulled from
+channel_id, data_type`` plus one column per configured KPI (see ``kpis``),
+one per identity key (the union across all ``channels``), and one per
+configured attribute key.  Identity/attribute values are pulled from
 each channel's in-memory ``identity`` / ``attributes`` dicts (null where a
 channel omits a key).  On an identity/attribute key collision, identity wins
 and the attribute is skipped.

--- a/docs/impulse/docs/references/api/impulse_reporting/channels/calculated_channel.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/channels/calculated_channel.md
@@ -178,3 +178,50 @@ Create the dimension DataFrame for the given channels.
 which ``createDataFrame`` builds directly from the plain dict returned by
 
 
+#### determine\_channel\_metrics
+
+```python
+def determine_channel_metrics(
+        cls,
+        spark: SparkSession,
+        channels: list[CalculatedChannel],
+        fact_df: DataFrame | None,
+        *,
+        attribute_columns: list[str] | None = None,
+        kpis: list[str] | None = None) -> DataFrame | None
+```
+
+Derive a silver-shaped ``channel_metrics`` DataFrame from the fact rows.
+
+The calculated-channel fact table already matches the silver ``channels``
+table; this builds its companion ``channel_metrics`` so the pair can serve
+as an Impulse silver source.  Metrics are aggregated **directly from the
+narrow fact rows** (``container_id, channel_id, tstart, tend, value``),
+grouped by ``(container_id, channel_id)``.
+
+The output schema is **dynamic**: fixed columns ``container_id,
+channel_id, type, data_type`` plus one column per configured KPI (see
+``kpis``), one per identity key (the union across all ``channels``), and one
+per configured attribute key.  Identity/attribute values are pulled from
+each channel's in-memory ``identity`` / ``attributes`` dicts (null where a
+channel omits a key).  On an identity/attribute key collision, identity wins
+and the attribute is skipped.
+
+**Arguments**:
+
+- `spark` (`SparkSession`): Session used to build the per-channel metadata frame.
+- `channels` (`list of CalculatedChannel`): The channels whose fact rows are in ``fact_df``; supply identity and
+attributes.
+- `fact_df` (`DataFrame or None`): Narrow fact DataFrame (output of :meth:`determine_calculated_channels`).
+``None`` returns ``None``.
+- `attribute_columns` (`list of str`): Attribute keys to surface as columns.  Default/empty → no attribute
+columns.  A key no channel defines yields an all-null column.
+- `kpis` (`list of str`): KPI names to compute (see ``calculated_channel_kpis.KPI_BUILDERS``); the
+output carries one column per name, in order.  ``None`` → the default
+KPIs (``duration, min, max, mean``).
+
+**Returns**:
+
+`DataFrame or None`: The dynamic-schema metrics DataFrame, or ``None`` when ``fact_df`` is
+``None``.
+

--- a/docs/impulse/docs/references/api/impulse_reporting/channels/calculated_channel.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/channels/calculated_channel.md
@@ -200,7 +200,7 @@ narrow fact rows** (``container_id, channel_id, tstart, tend, value``),
 grouped by ``(container_id, channel_id)``.
 
 The output schema is **dynamic**: fixed columns ``container_id,
-channel_id, data_type`` plus one column per configured KPI (see ``kpis``),
+channel_id, value_type`` plus one column per configured KPI (see ``kpis``),
 one per identity key (the union across all ``channels``), and one per
 configured attribute key.  Identity/attribute values are pulled from
 each channel's in-memory ``identity`` / ``attributes`` dicts (null where a

--- a/docs/impulse/docs/references/api/impulse_reporting/channels/channel_types.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/channels/channel_types.md
@@ -67,6 +67,28 @@ Get the dimension table name for the channel type.
 
 `str`: The name of the dimension table associated with this channel type.
 
+#### get\_metrics\_table\_name
+
+```python
+def get_metrics_table_name() -> str
+```
+
+Get the (optional) channel-metrics table name for the channel type.
+
+This table mirrors the silver-layer ``channel_metrics`` table so the
+calculated-channel fact + metrics pair can serve as an Impulse silver
+source.  Unlike the fact/dimension tables it has **no** fixed schema
+constant: identity/attribute columns are derived dynamically per report
+(see :meth:`CalculatedChannel.determine_channel_metrics`).
+
+**Raises**:
+
+- `ValueError`: If the channel type is not supported.
+
+**Returns**:
+
+`str`: The name of the channel-metrics table associated with this channel type.
+
 #### get\_dimension\_schema
 
 ```python
@@ -94,6 +116,26 @@ Return the first ChannelType whose fact table name matches.
 **Arguments**:
 
 - `table_name` (`str`): Fact table name to look up.
+
+**Raises**:
+
+- `ValueError`: If no ChannelType matches the given table name.
+
+**Returns**:
+
+`ChannelType`: 
+
+#### get\_any\_for\_metrics\_table
+
+```python
+def get_any_for_metrics_table(cls, table_name: str) -> "ChannelType"
+```
+
+Return the first ChannelType whose metrics table name matches.
+
+**Arguments**:
+
+- `table_name` (`str`): Metrics table name to look up.
 
 **Raises**:
 

--- a/docs/impulse/docs/references/api/impulse_reporting/config/config_parser.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/config/config_parser.md
@@ -237,6 +237,27 @@ Configuration for incremental processing behavior.
 - `silver_last_modified_column` (`str, default="timestamp"`): Column name in the silver layer used for freshness comparison.
 - `gold_last_modified_column` (`str, default="last_modified"`): Column name in the gold layer used for freshness comparison.
 
+## CalculatedChannels
+
+```python
+class CalculatedChannels(BaseModel)
+```
+
+Configuration for calculated-channel outputs.
+
+**Arguments**:
+
+- `emit_channel_metrics` (`bool, default=False`): When True, also emit a ``calculated_channel_metrics`` gold table (silver
+``channel_metrics`` shape) alongside the calculated-channel fact table, so
+the fact + metrics pair can serve as an Impulse silver source.
+- `attribute_columns` (`list of str, default=[]`): Calculated-channel attribute keys to surface as columns on the metrics
+table (e.g. ``["unit"]``). Empty (the default) → no attribute columns.
+Identity keys are always surfaced dynamically and win over an
+attribute key of the same name.
+- `kpis` (`list of str, default=["duration", "min", "max", "mean"]`): KPIs computed on the metrics table, one column per name. Each must be a
+registered KPI (see ``calculated_channel_kpis.KPI_BUILDERS``); an unknown
+name is rejected at validation. Duplicates are removed (order preserved).
+
 ## ImpulseConfig
 
 ```python
@@ -257,6 +278,9 @@ Attributes
      Optional query engine configuration. Defaults to Solvers.DEFAULT_SOLVER.
  incremental : IncrementalConfig, optional
      Optional incremental processing configuration. Defaults to IncrementalConfig().
+ calculated_channels : CalculatedChannels, optional
+     Optional calculated-channel output configuration (e.g. opting in to the
+     ``calculated_channel_metrics`` table). Defaults to CalculatedChannels().
  measurement_dimensions : list of str, optional
      Column names to surface from ``container_metrics`` into the
      gold-layer ``measurement_dimension`` table. Names are matched

--- a/docs/impulse/docs/references/report/channel.md
+++ b/docs/impulse/docs/references/report/channel.md
@@ -138,3 +138,33 @@ run-length-encoded shape as the silver `channels` table.
 Both tables carry the configurable `table_prefix` (e.g. `{prefix}_calculated_channel_fact`). See the
 [gold layer schema](../../data_model/gold_layer_event_normalized.md) for how they fit the star schema, and
 [incremental processing](./index.md#incremental-processing) for how definition changes are reprocessed.
+
+---
+
+## Optional channel metrics table
+
+Because `calculated_channel_fact` already matches the silver `channels` shape, a calculated channel needs
+only a companion `channel_metrics` table to serve as an Impulse silver source in its own right. Set
+[`config.calculated_channels.emit_channel_metrics`](../../config/configuration.md#calculated_channels-optional)
+to also write a `calculated_channel_metrics` table, shaped like the silver `channel_metrics` table.
+
+### calculated_channel_metrics
+
+One row per `(container_id, channel_id)`, derived directly from the fact rows. The schema is **dynamic**:
+fixed columns plus one column per configured KPI, one per identity key (the union of `identity` keys across
+the report's channels), and one per configured attribute key.
+
+| Column         | Type     | Description                                                                                     |
+|----------------|----------|-------------------------------------------------------------------------------------------------|
+| `container_id` | `int`    | Container identifier. Type is inherited from the silver source.                                 |
+| `channel_id`   | `long`   | Calculated-channel identifier (matches the fact and dimension).                                 |
+| *identity cols*| `str`    | One column per identity key (e.g. `channel_name`, `data_key`); `null` where a channel omits it. |
+| *attribute cols*| `str`   | One column per `attribute_columns` entry (e.g. `unit`); `null` where a channel omits it.        |
+| `type`         | `str`    | `"CALC"`.                                                                                        |
+| `data_type`    | `str`    | `"double"`.                                                                                      |
+| *kpi cols*     | `double` | One column per configured KPI, in order (default `duration`, `min`, `max`, `mean`).             |
+
+The KPIs are duration-weighted (matching the silver ingestion semantics): `duration` is the span
+`max(tend) - min(tstart)`, `min` / `max` ignore NaN values, and `mean` is the duration-weighted average.
+Select which KPIs to compute via `config.calculated_channels.kpis`; an identity key wins over an attribute
+key of the same name.

--- a/docs/impulse/docs/references/report/channel.md
+++ b/docs/impulse/docs/references/report/channel.md
@@ -160,7 +160,7 @@ the report's channels), and one per configured attribute key.
 | `channel_id`   | `long`   | Calculated-channel identifier (matches the fact and dimension).                                 |
 | *identity cols*| `str`    | One column per identity key (e.g. `channel_name`, `data_key`); `null` where a channel omits it. |
 | *attribute cols*| `str`   | One column per `attribute_columns` entry (e.g. `unit`); `null` where a channel omits it.        |
-| `data_type`    | `str`    | `"double"`.                                                                                      |
+| `value_type`   | `str`    | `"double"`.                                                                                      |
 | *kpi cols*     | `double` | One column per configured KPI, in order (default `duration`, `min`, `max`, `mean`).             |
 
 The KPIs are duration-weighted (matching the silver ingestion semantics): `duration` is the span

--- a/docs/impulse/docs/references/report/channel.md
+++ b/docs/impulse/docs/references/report/channel.md
@@ -160,7 +160,6 @@ the report's channels), and one per configured attribute key.
 | `channel_id`   | `long`   | Calculated-channel identifier (matches the fact and dimension).                                 |
 | *identity cols*| `str`    | One column per identity key (e.g. `channel_name`, `data_key`); `null` where a channel omits it. |
 | *attribute cols*| `str`   | One column per `attribute_columns` entry (e.g. `unit`); `null` where a channel omits it.        |
-| `type`         | `str`    | `"CALC"`.                                                                                        |
 | `data_type`    | `str`    | `"double"`.                                                                                      |
 | *kpi cols*     | `double` | One column per configured KPI, in order (default `duration`, `min`, `max`, `mean`).             |
 

--- a/skills/impulse-channels/SKILL.md
+++ b/skills/impulse-channels/SKILL.md
@@ -5,8 +5,8 @@ description: >
   channels and materialized at the same per-sample grain. Use when the user wants to "add a calculated
   channel", derive/persist a signal (e.g. "speed in km/h", "power = rpm × torque"), materialize a virtual
   signal into a queryable table, or run `solve_calculated_channels`. Covers the reporting-layer
-  CalculatedChannel, the ad-hoc `QueryBuilder.solve_calculated_channels` endpoint, and the
-  calculated_channel_fact/dimension gold output.
+  CalculatedChannel, the ad-hoc `QueryBuilder.solve_calculated_channels` endpoint, the
+  calculated_channel_fact/dimension gold output, and the optional calculated_channel_metrics table.
 ---
 
 # Impulse — calculated channels
@@ -97,6 +97,30 @@ across selections.
 `tstart`, `tend`, `value`. Same narrow, run-length-encoded shape as the silver `channels` table. The
 identity is **not** on the fact — it lives on the dimension; join on `channel_id` (and to
 `measurement_dimension` on `container_id`; see `impulse-data-model`).
+
+## Optional channel metrics table
+
+`calculated_channel_fact` already matches the silver `channels` shape, so a calculated channel needs only a
+companion `channel_metrics` table to become an Impulse silver source. Set
+`config.calculated_channels.emit_channel_metrics = True` to also write `calculated_channel_metrics`, shaped
+like silver `channel_metrics` (one row per `(container_id, channel_id)`, derived from the fact rows).
+
+```python
+from impulse_reporting.config.config_parser import CalculatedChannels
+
+# in the ImpulseConfig:
+calculated_channels = CalculatedChannels(
+    emit_channel_metrics=True,
+    attribute_columns=["unit"],          # attribute keys to surface as columns; default []
+    kpis=["duration", "min", "max", "mean"],  # default; each must be a registered KPI
+)
+```
+
+The schema is **dynamic**: fixed `container_id`, `channel_id`, `type` (`"CALC"`), `data_type` (`"double"`),
+one column per configured KPI, one per identity key (union across the report's channels), and one per
+`attribute_columns` entry. `null` fills a key a channel omits; an identity key wins over an attribute key of
+the same name. KPIs are duration-weighted; an unknown KPI name is rejected at config validation. Adding a
+new KPI is a one-line entry in `impulse_reporting.channels.calculated_channel_kpis.KPI_BUILDERS`.
 
 ## Incremental
 

--- a/skills/impulse-channels/SKILL.md
+++ b/skills/impulse-channels/SKILL.md
@@ -116,7 +116,7 @@ calculated_channels = CalculatedChannels(
 )
 ```
 
-The schema is **dynamic**: fixed `container_id`, `channel_id`, `type` (`"CALC"`), `data_type` (`"double"`),
+The schema is **dynamic**: fixed `container_id`, `channel_id`, `data_type` (`"double"`),
 one column per configured KPI, one per identity key (union across the report's channels), and one per
 `attribute_columns` entry. `null` fills a key a channel omits; an identity key wins over an attribute key of
 the same name. KPIs are duration-weighted; an unknown KPI name is rejected at config validation. Adding a

--- a/skills/impulse-channels/SKILL.md
+++ b/skills/impulse-channels/SKILL.md
@@ -116,7 +116,7 @@ calculated_channels = CalculatedChannels(
 )
 ```
 
-The schema is **dynamic**: fixed `container_id`, `channel_id`, `data_type` (`"double"`),
+The schema is **dynamic**: fixed `container_id`, `channel_id`, `value_type` (`"double"`),
 one column per configured KPI, one per identity key (union across the report's channels), and one per
 `attribute_columns` entry. `null` fills a key a channel omits; an identity key wins over an attribute key of
 the same name. KPIs are duration-weighted; an unknown KPI name is rejected at config validation. Adding a

--- a/skills/impulse-config/SKILL.md
+++ b/skills/impulse-config/SKILL.md
@@ -6,7 +6,7 @@ description: >
   "configure an Impulse report", set the source/sink tables, filter which containers are processed,
   choose RLE vs RAW, turn on incremental processing, run without writing (sinkless), remap column
   names, or scope by project. Covers source, unity_sink, container_filters, query_engine, solver_config,
-  incremental, and measurement_dimensions, all validated by Pydantic.
+  incremental, measurement_dimensions, and calculated_channels, all validated by Pydantic.
 ---
 
 # Impulse — configuration
@@ -40,6 +40,7 @@ config = {
     },
     "incremental": {"enabled": True},
     "measurement_dimensions": ["container_id", "vehicle_key", "start_ts", "stop_ts"],
+    "calculated_channels": {"emit_channel_metrics": True, "attribute_columns": ["unit"]},  # optional
 }
 ```
 
@@ -172,3 +173,19 @@ List of `container_metrics` columns (post-mapping **internal** names) to surface
 Default: `["container_id", "start_ts", "stop_ts"]`. Keep `container_id` — it is the incremental upsert
 key and the join key to fact tables. Any column present in your post-mapping `container_metrics`
 DataFrame is valid; a missing one fails the run fast with a `ValueError` naming it.
+
+## calculated_channels (optional)
+
+Controls the optional `calculated_channel_metrics` table. Off by default; when on, it is written alongside
+`calculated_channel_fact` / `calculated_channel_dimension` in the silver `channel_metrics` shape, so the
+fact + metrics pair can serve as an Impulse silver source. See `impulse-channels`.
+
+| Field                  | Default                              | Description                                                                 |
+|------------------------|--------------------------------------|-----------------------------------------------------------------------------|
+| `emit_channel_metrics` | `false`                              | Turn on the `calculated_channel_metrics` table.                             |
+| `attribute_columns`    | `[]`                                 | Calculated-channel `attributes` keys to surface as columns (e.g. `["unit"]`). |
+| `kpis`                 | `["duration", "min", "max", "mean"]` | KPIs computed per `(container_id, channel_id)`, one column each.            |
+
+Each metrics row is one `(container_id, channel_id)` pair with the selected `kpis` (duration-weighted) plus
+dynamic identity columns (union of `identity` keys) and the configured `attribute_columns`; identity wins
+over an attribute of the same name. An unknown KPI name is rejected at config validation.

--- a/skills/impulse-data-model/SKILL.md
+++ b/skills/impulse-data-model/SKILL.md
@@ -96,6 +96,7 @@ A star schema. Every table is prefixed with your configured `table_prefix` (e.g.
 | `histogram2d_fact`      | One row per (x, y) bin per container     |
 | `stats_aggregator_fact` | One row per statistic label per signal per event instance |
 | `calculated_channel_fact` | One row per sample interval per container (a derived signal, silver `channels` shape) |
+| `calculated_channel_metrics` | One row per calculated channel per container (optional; silver `channel_metrics` shape). Written only when `config.calculated_channels.emit_channel_metrics` is set. See `impulse-channels`. |
 
 **Dimension tables**
 

--- a/src/impulse_reporting/channels/calculated_channel.py
+++ b/src/impulse_reporting/channels/calculated_channel.py
@@ -16,8 +16,25 @@ from impulse_query_engine.analyze.query.channels.calculated_channel import (
 from impulse_query_engine.analyze.query.query_builder import QueryBuilder
 from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
 from impulse_query_engine.model.series.sample_series import SampleSeries
+from impulse_reporting.channels.calculated_channel_kpis import (
+    DEFAULT_KPIS,
+    build_kpi_columns,
+)
 from impulse_reporting.persist.dimension_schema import CALCULATED_CHANNEL_DIMENSION_SCHEMA
 from impulse_reporting.persist.fact_schema import CALCULATED_CHANNEL_FACT_SCHEMA
+
+
+def _union_identity_keys(channels: list[CalculatedChannel]) -> list[str]:
+    """Return the sorted union of identity keys across ``channels``.
+
+    Used to build the dynamic identity columns of the calculated-channel metrics
+    table: every key any channel declares becomes a column (null on channels that
+    omit it). Sorting gives a stable, order-independent column layout.
+    """
+    keys: set[str] = set()
+    for channel in channels:
+        keys.update(channel.identity)
+    return sorted(keys)
 
 
 class CalculatedChannel:
@@ -217,6 +234,7 @@ class CalculatedChannel:
         fact_df: DataFrame | None,
         *,
         attribute_columns: list[str] | None = None,
+        kpis: list[str] | None = None,
     ) -> DataFrame | None:
         """Derive a silver-shaped ``channel_metrics`` DataFrame from the fact rows.
 
@@ -224,16 +242,15 @@ class CalculatedChannel:
         table; this builds its companion ``channel_metrics`` so the pair can serve
         as an Impulse silver source.  Metrics are aggregated **directly from the
         narrow fact rows** (``container_id, channel_id, tstart, tend, value``),
-        grouped by ``(container_id, channel_id)`` with duration-weighted semantics
-        matching :class:`SampleSeries` (``dur = tend - tstart``).
+        grouped by ``(container_id, channel_id)``.
 
         The output schema is **dynamic**: fixed columns ``container_id,
-        channel_id, type, data_type, duration, min, max, mean`` plus one column per
-        identity key (the union across all ``channels``) and one per configured
-        attribute key.  Identity/attribute values are pulled from each channel's
-        in-memory ``identity`` / ``attributes`` dicts (null where a channel omits a
-        key).  On an identity/attribute key collision, identity wins and the
-        attribute is skipped.
+        channel_id, type, data_type`` plus one column per configured KPI (see
+        ``kpis``), one per identity key (the union across all ``channels``), and one
+        per configured attribute key.  Identity/attribute values are pulled from
+        each channel's in-memory ``identity`` / ``attributes`` dicts (null where a
+        channel omits a key).  On an identity/attribute key collision, identity wins
+        and the attribute is skipped.
 
         Parameters
         ----------
@@ -248,6 +265,10 @@ class CalculatedChannel:
         attribute_columns : list of str, optional
             Attribute keys to surface as columns.  Default/empty → no attribute
             columns.  A key no channel defines yields an all-null column.
+        kpis : list of str, optional
+            KPI names to compute (see ``calculated_channel_kpis.KPI_BUILDERS``); the
+            output carries one column per name, in order.  ``None`` → the default
+            KPIs (``duration, min, max, mean``).
 
         Returns
         -------
@@ -259,29 +280,15 @@ class CalculatedChannel:
             return None
 
         attribute_columns = list(attribute_columns or [])
+        kpis = list(kpis) if kpis is not None else list(DEFAULT_KPIS)
 
-        # Duration-weighted aggregation matching SampleSeries semantics. NaN values
-        # are nulled so Spark's min/max/sum skip them (matching np.nanmin / nanmax /
-        # nansum); the mean denominator keeps every interval's duration.
-        dur = F.col("tend") - F.col("tstart")
-        value = F.col("value")
-        non_nan_value = F.when(~F.isnan(value), value)
-        weighted_value = F.when(~F.isnan(value), value * dur).otherwise(F.lit(0.0))
-        agg_df = fact_df.groupBy("container_id", "channel_id").agg(
-            (F.max("tend") - F.min("tstart")).alias("duration"),
-            F.min(non_nan_value).alias("min"),
-            F.max(non_nan_value).alias("max"),
-            (F.sum(weighted_value) / F.sum(dur)).alias("mean"),
-        )
+        # KPI aggregations are built from the registry (single extension point), so
+        # the computed columns and the projection below both follow ``kpis``.
+        agg_df = fact_df.groupBy("container_id", "channel_id").agg(*build_kpi_columns(kpis))
 
         # Union of identity keys (stable order); attribute columns lose to identity
         # on a key collision.
-        identity_keys: list[str] = []
-        for channel in channels:
-            for key in channel.identity:
-                if key not in identity_keys:
-                    identity_keys.append(key)
-        identity_keys.sort()
+        identity_keys = _union_identity_keys(channels)
         effective_attribute_keys = [k for k in attribute_columns if k not in identity_keys]
 
         # Per-channel metadata frame. channel_id is cast to the fact's channel_id
@@ -312,6 +319,7 @@ class CalculatedChannel:
             ["container_id", "channel_id"]
             + identity_keys
             + effective_attribute_keys
-            + ["type", "data_type", "duration", "min", "max", "mean"]
+            + ["type", "data_type"]
+            + kpis
         )
         return result.select(*ordered_columns)

--- a/src/impulse_reporting/channels/calculated_channel.py
+++ b/src/impulse_reporting/channels/calculated_channel.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping
 
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
 from pyspark.sql import DataFrame, Row, SparkSession
 
 from impulse_query_engine.analyze.metadata.time_series_expression import (
@@ -206,3 +208,110 @@ class CalculatedChannel:
         """
         rows = [channel.as_spark_row() for channel in channels]
         return spark.createDataFrame(rows, schema=CALCULATED_CHANNEL_DIMENSION_SCHEMA)
+
+    @classmethod
+    def determine_channel_metrics(
+        cls,
+        spark: SparkSession,
+        channels: list[CalculatedChannel],
+        fact_df: DataFrame | None,
+        *,
+        attribute_columns: list[str] | None = None,
+    ) -> DataFrame | None:
+        """Derive a silver-shaped ``channel_metrics`` DataFrame from the fact rows.
+
+        The calculated-channel fact table already matches the silver ``channels``
+        table; this builds its companion ``channel_metrics`` so the pair can serve
+        as an Impulse silver source.  Metrics are aggregated **directly from the
+        narrow fact rows** (``container_id, channel_id, tstart, tend, value``),
+        grouped by ``(container_id, channel_id)`` with duration-weighted semantics
+        matching :class:`SampleSeries` (``dur = tend - tstart``).
+
+        The output schema is **dynamic**: fixed columns ``container_id,
+        channel_id, type, data_type, duration, min, max, mean`` plus one column per
+        identity key (the union across all ``channels``) and one per configured
+        attribute key.  Identity/attribute values are pulled from each channel's
+        in-memory ``identity`` / ``attributes`` dicts (null where a channel omits a
+        key).  On an identity/attribute key collision, identity wins and the
+        attribute is skipped.
+
+        Parameters
+        ----------
+        spark : SparkSession
+            Session used to build the per-channel metadata frame.
+        channels : list of CalculatedChannel
+            The channels whose fact rows are in ``fact_df``; supply identity and
+            attributes.
+        fact_df : DataFrame or None
+            Narrow fact DataFrame (output of :meth:`determine_calculated_channels`).
+            ``None`` returns ``None``.
+        attribute_columns : list of str, optional
+            Attribute keys to surface as columns.  Default/empty → no attribute
+            columns.  A key no channel defines yields an all-null column.
+
+        Returns
+        -------
+        DataFrame or None
+            The dynamic-schema metrics DataFrame, or ``None`` when ``fact_df`` is
+            ``None``.
+        """
+        if fact_df is None:
+            return None
+
+        attribute_columns = list(attribute_columns or [])
+
+        # Duration-weighted aggregation matching SampleSeries semantics. NaN values
+        # are nulled so Spark's min/max/sum skip them (matching np.nanmin / nanmax /
+        # nansum); the mean denominator keeps every interval's duration.
+        dur = F.col("tend") - F.col("tstart")
+        value = F.col("value")
+        non_nan_value = F.when(~F.isnan(value), value)
+        weighted_value = F.when(~F.isnan(value), value * dur).otherwise(F.lit(0.0))
+        agg_df = fact_df.groupBy("container_id", "channel_id").agg(
+            (F.max("tend") - F.min("tstart")).alias("duration"),
+            F.min(non_nan_value).alias("min"),
+            F.max(non_nan_value).alias("max"),
+            (F.sum(weighted_value) / F.sum(dur)).alias("mean"),
+        )
+
+        # Union of identity keys (stable order); attribute columns lose to identity
+        # on a key collision.
+        identity_keys: list[str] = []
+        for channel in channels:
+            for key in channel.identity:
+                if key not in identity_keys:
+                    identity_keys.append(key)
+        identity_keys.sort()
+        effective_attribute_keys = [k for k in attribute_columns if k not in identity_keys]
+
+        # Per-channel metadata frame. channel_id is cast to the fact's channel_id
+        # type so the join keys line up regardless of int/long width.
+        channel_id_type = fact_df.schema["channel_id"].dataType
+        meta_schema = T.StructType(
+            [T.StructField("channel_id", channel_id_type, False)]
+            + [T.StructField(k, T.StringType(), True) for k in identity_keys]
+            + [T.StructField(k, T.StringType(), True) for k in effective_attribute_keys]
+        )
+        meta_rows = []
+        for channel in channels:
+            row: dict = {"channel_id": channel.get_id()}
+            for key in identity_keys:
+                row[key] = channel.identity.get(key)
+            for key in effective_attribute_keys:
+                row[key] = channel.attributes.get(key)
+            meta_rows.append(Row(**row))
+        meta_df = spark.createDataFrame(meta_rows, schema=meta_schema)
+
+        result = (
+            agg_df.join(meta_df, on="channel_id", how="left")
+            .withColumn("type", F.lit("CALC"))
+            .withColumn("data_type", F.lit("double"))
+        )
+
+        ordered_columns = (
+            ["container_id", "channel_id"]
+            + identity_keys
+            + effective_attribute_keys
+            + ["type", "data_type", "duration", "min", "max", "mean"]
+        )
+        return result.select(*ordered_columns)

--- a/src/impulse_reporting/channels/calculated_channel.py
+++ b/src/impulse_reporting/channels/calculated_channel.py
@@ -245,9 +245,9 @@ class CalculatedChannel:
         grouped by ``(container_id, channel_id)``.
 
         The output schema is **dynamic**: fixed columns ``container_id,
-        channel_id, type, data_type`` plus one column per configured KPI (see
-        ``kpis``), one per identity key (the union across all ``channels``), and one
-        per configured attribute key.  Identity/attribute values are pulled from
+        channel_id, data_type`` plus one column per configured KPI (see ``kpis``),
+        one per identity key (the union across all ``channels``), and one per
+        configured attribute key.  Identity/attribute values are pulled from
         each channel's in-memory ``identity`` / ``attributes`` dicts (null where a
         channel omits a key).  On an identity/attribute key collision, identity wins
         and the attribute is skipped.
@@ -309,17 +309,15 @@ class CalculatedChannel:
             meta_rows.append(Row(**row))
         meta_df = spark.createDataFrame(meta_rows, schema=meta_schema)
 
-        result = (
-            agg_df.join(meta_df, on="channel_id", how="left")
-            .withColumn("type", F.lit("CALC"))
-            .withColumn("data_type", F.lit("double"))
+        result = agg_df.join(meta_df, on="channel_id", how="left").withColumn(
+            "data_type", F.lit("double")
         )
 
         ordered_columns = (
             ["container_id", "channel_id"]
             + identity_keys
             + effective_attribute_keys
-            + ["type", "data_type"]
+            + ["data_type"]
             + kpis
         )
         return result.select(*ordered_columns)

--- a/src/impulse_reporting/channels/calculated_channel.py
+++ b/src/impulse_reporting/channels/calculated_channel.py
@@ -245,7 +245,7 @@ class CalculatedChannel:
         grouped by ``(container_id, channel_id)``.
 
         The output schema is **dynamic**: fixed columns ``container_id,
-        channel_id, data_type`` plus one column per configured KPI (see ``kpis``),
+        channel_id, value_type`` plus one column per configured KPI (see ``kpis``),
         one per identity key (the union across all ``channels``), and one per
         configured attribute key.  Identity/attribute values are pulled from
         each channel's in-memory ``identity`` / ``attributes`` dicts (null where a
@@ -310,14 +310,14 @@ class CalculatedChannel:
         meta_df = spark.createDataFrame(meta_rows, schema=meta_schema)
 
         result = agg_df.join(meta_df, on="channel_id", how="left").withColumn(
-            "data_type", F.lit("double")
+            "value_type", F.lit("double")
         )
 
         ordered_columns = (
             ["container_id", "channel_id"]
             + identity_keys
             + effective_attribute_keys
-            + ["data_type"]
+            + ["value_type"]
             + kpis
         )
         return result.select(*ordered_columns)

--- a/src/impulse_reporting/channels/calculated_channel_kpis.py
+++ b/src/impulse_reporting/channels/calculated_channel_kpis.py
@@ -1,0 +1,104 @@
+"""Registry of calculated-channel metric KPIs.
+
+Each KPI is a named builder that returns a Spark aggregation :class:`Column`
+(already ``.alias(name)``-ed) computed over the narrow calculated-channel fact
+rows grouped by ``(container_id, channel_id)``.  The registry is the single
+extension point for the ``calculated_channel_metrics`` table: **adding a KPI means
+adding one entry to** :data:`KPI_BUILDERS` — it then becomes selectable via
+``CalculatedChannels.kpis`` config with no other changes.
+
+Semantics match :class:`SampleSeries` (duration-weighted where relevant), with
+``dur = tend - tstart``.  NaN values are excluded from ``min``/``max``/``mean``
+(matching ``np.nanmin`` / ``nanmax`` / ``nansum``); the ``mean`` denominator keeps
+every interval's duration and uses ``try_divide`` so a zero total duration (a group
+of only zero-duration point-in-time samples) yields ``null`` instead of failing the
+run under ANSI mode (Spark 4.0 default).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pyspark.sql.functions as F
+from pyspark.sql import Column
+
+
+@dataclass(frozen=True)
+class KpiColumns:
+    """Reusable per-group column expressions shared by the KPI builders.
+
+    Built once per aggregation from the fact columns so each builder does not
+    recompute the duration / NaN-masking expressions.
+    """
+
+    dur: Column
+    value: Column
+    non_nan_value: Column
+    weighted_value: Column
+
+    @classmethod
+    def from_fact(cls) -> "KpiColumns":
+        """Build the shared expressions from the fixed fact column names."""
+        dur = F.col("tend") - F.col("tstart")
+        value = F.col("value")
+        non_nan_value = F.when(~F.isnan(value), value)
+        weighted_value = F.when(~F.isnan(value), value * dur).otherwise(F.lit(0.0))
+        return cls(
+            dur=dur, value=value, non_nan_value=non_nan_value, weighted_value=weighted_value
+        )
+
+
+def _duration(cols: KpiColumns) -> Column:
+    return (F.max("tend") - F.min("tstart")).alias("duration")
+
+
+def _min(cols: KpiColumns) -> Column:
+    return F.min(cols.non_nan_value).alias("min")
+
+
+def _max(cols: KpiColumns) -> Column:
+    return F.max(cols.non_nan_value).alias("max")
+
+
+def _mean(cols: KpiColumns) -> Column:
+    # Duration-weighted; try_divide → null (not error) when total duration is zero.
+    return F.try_divide(F.sum(cols.weighted_value), F.sum(cols.dur)).alias("mean")
+
+
+# Name → aggregation-Column builder. Adding a KPI = adding one entry here.
+KPI_BUILDERS: dict[str, Callable[[KpiColumns], Column]] = {
+    "duration": _duration,
+    "min": _min,
+    "max": _max,
+    "mean": _mean,
+}
+
+# Default KPIs computed when config does not narrow the selection.
+DEFAULT_KPIS: list[str] = ["duration", "min", "max", "mean"]
+
+
+def build_kpi_columns(names: list[str]) -> list[Column]:
+    """Return the aggregation columns for ``names`` in the given order.
+
+    Parameters
+    ----------
+    names : list of str
+        KPI names to compute; each must be a key of :data:`KPI_BUILDERS`.
+
+    Returns
+    -------
+    list of Column
+        Aliased aggregation columns, one per name, ready to splat into ``.agg``.
+
+    Raises
+    ------
+    ValueError
+        If any name is not a registered KPI.
+    """
+    unknown = [n for n in names if n not in KPI_BUILDERS]
+    if unknown:
+        valid = ", ".join(sorted(KPI_BUILDERS))
+        raise ValueError(f"Unknown calculated-channel KPI(s): {unknown}. Valid KPIs: {valid}.")
+    cols = KpiColumns.from_fact()
+    return [KPI_BUILDERS[name](cols) for name in names]

--- a/src/impulse_reporting/channels/channel_types.py
+++ b/src/impulse_reporting/channels/channel_types.py
@@ -83,6 +83,32 @@ class ChannelType(Enum):
             case _:
                 raise ValueError(f"Unsupported channel type: {self}")
 
+    def get_metrics_table_name(self) -> str:
+        """
+        Get the (optional) channel-metrics table name for the channel type.
+
+        This table mirrors the silver-layer ``channel_metrics`` table so the
+        calculated-channel fact + metrics pair can serve as an Impulse silver
+        source.  Unlike the fact/dimension tables it has **no** fixed schema
+        constant: identity/attribute columns are derived dynamically per report
+        (see :meth:`CalculatedChannel.determine_channel_metrics`).
+
+        Returns
+        -------
+        str
+            The name of the channel-metrics table associated with this channel type.
+
+        Raises
+        ------
+        ValueError
+            If the channel type is not supported.
+        """
+        match self:
+            case ChannelType.CALCULATED_CHANNEL:
+                return "calculated_channel_metrics"
+            case _:
+                raise ValueError(f"Unsupported channel type: {self}")
+
     def get_dimension_schema(self) -> StructType:
         """
         Get the dimension schema for the channel type.
@@ -125,6 +151,29 @@ class ChannelType(Enum):
             if ct.get_fact_table_name() == table_name:
                 return ct
         raise ValueError(f"No ChannelType found for fact table: {table_name}")
+
+    @classmethod
+    def get_any_for_metrics_table(cls, table_name: str) -> "ChannelType":
+        """Return the first ChannelType whose metrics table name matches.
+
+        Parameters
+        ----------
+        table_name : str
+            Metrics table name to look up.
+
+        Returns
+        -------
+        ChannelType
+
+        Raises
+        ------
+        ValueError
+            If no ChannelType matches the given table name.
+        """
+        for ct in cls:
+            if ct.get_metrics_table_name() == table_name:
+                return ct
+        raise ValueError(f"No ChannelType found for metrics table: {table_name}")
 
     @classmethod
     def get_any_for_dimension_table(cls, table_name: str) -> "ChannelType":

--- a/src/impulse_reporting/config/config_parser.py
+++ b/src/impulse_reporting/config/config_parser.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from pydantic import AfterValidator, BaseModel, field_validator, model_validator
 
 from impulse_query_engine.analyze.query.solvers.solver_config import RawEncoder, SolverConfig
+from impulse_reporting.channels.calculated_channel_kpis import DEFAULT_KPIS, KPI_BUILDERS
 
 
 def is_valid_table_name(table_name: str) -> str:
@@ -451,10 +452,15 @@ class CalculatedChannels(BaseModel):
         table (e.g. ``["unit"]``). Empty (the default) → no attribute columns.
         Identity keys are always surfaced dynamically and win over an
         attribute key of the same name.
+    kpis : list of str, default=["duration", "min", "max", "mean"]
+        KPIs computed on the metrics table, one column per name. Each must be a
+        registered KPI (see ``calculated_channel_kpis.KPI_BUILDERS``); an unknown
+        name is rejected at validation. Duplicates are removed (order preserved).
     """
 
     emit_channel_metrics: bool = False
     attribute_columns: list[str] = []
+    kpis: list[str] = list(DEFAULT_KPIS)
 
     @field_validator("attribute_columns", mode="after")
     @classmethod
@@ -463,6 +469,20 @@ class CalculatedChannels(BaseModel):
         normalized: list[str] = []
         for name in value:
             is_valid_unity_entity_name(name)
+            if name not in seen:
+                seen.add(name)
+                normalized.append(name)
+        return normalized
+
+    @field_validator("kpis", mode="after")
+    @classmethod
+    def _normalize_kpis(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for name in value:
+            if name not in KPI_BUILDERS:
+                valid = ", ".join(sorted(KPI_BUILDERS))
+                raise ValueError(f"Unknown calculated-channel KPI: {name}. Valid KPIs: {valid}.")
             if name not in seen:
                 seen.add(name)
                 normalized.append(name)

--- a/src/impulse_reporting/config/config_parser.py
+++ b/src/impulse_reporting/config/config_parser.py
@@ -436,6 +436,39 @@ class IncrementalConfig(BaseModel):
     gold_last_modified_column: str = "_created_at"
 
 
+class CalculatedChannels(BaseModel):
+    """
+    Configuration for calculated-channel outputs.
+
+    Attributes
+    ----------
+    emit_channel_metrics : bool, default=False
+        When True, also emit a ``calculated_channel_metrics`` gold table (silver
+        ``channel_metrics`` shape) alongside the calculated-channel fact table, so
+        the fact + metrics pair can serve as an Impulse silver source.
+    attribute_columns : list of str, default=[]
+        Calculated-channel attribute keys to surface as columns on the metrics
+        table (e.g. ``["unit"]``). Empty (the default) → no attribute columns.
+        Identity keys are always surfaced dynamically and win over an
+        attribute key of the same name.
+    """
+
+    emit_channel_metrics: bool = False
+    attribute_columns: list[str] = []
+
+    @field_validator("attribute_columns", mode="after")
+    @classmethod
+    def _normalize_attribute_columns(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for name in value:
+            is_valid_unity_entity_name(name)
+            if name not in seen:
+                seen.add(name)
+                normalized.append(name)
+        return normalized
+
+
 class ImpulseConfig(BaseModel):
     """
      Main configuration model.
@@ -452,6 +485,9 @@ class ImpulseConfig(BaseModel):
          Optional query engine configuration. Defaults to Solvers.DEFAULT_SOLVER.
      incremental : IncrementalConfig, optional
          Optional incremental processing configuration. Defaults to IncrementalConfig().
+     calculated_channels : CalculatedChannels, optional
+         Optional calculated-channel output configuration (e.g. opting in to the
+         ``calculated_channel_metrics`` table). Defaults to CalculatedChannels().
      measurement_dimensions : list of str, optional
          Column names to surface from ``container_metrics`` into the
          gold-layer ``measurement_dimension`` table. Names are matched
@@ -526,6 +562,7 @@ class ImpulseConfig(BaseModel):
     container_filters: ContainerFilters | None = None
     query_engine: QueryEngine = QueryEngine(solver=Solvers.DEFAULT_SOLVER)
     incremental: IncrementalConfig | None = None
+    calculated_channels: CalculatedChannels = CalculatedChannels()
 
     measurement_dimensions: list[str] = list(DEFAULT_MEASUREMENT_DIMENSIONS)
 

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -106,6 +106,7 @@ class Report:
         self.aggregation_metadata_dfs = {}
         self.calculated_channel_dfs = {}
         self.calculated_channel_metadata_dfs = {}
+        self.calculated_channel_metrics_dfs = {}
         self.container_dimension_df = None
         self.channel_mapping_resolution_dimension_df = None
         self._is_incremental = None
@@ -598,6 +599,10 @@ class Report:
         persist_facts_full(self.calculated_channel_dfs, ChannelType, storage_factory)
         persist_dimensions_full(self.calculated_channel_metadata_dfs, ChannelType, storage_factory)
 
+        # optional calculated channel metrics table (dynamic schema — stored
+        # directly without the fixed-schema projecting writer)
+        self._persist_channel_metrics(incremental=False)
+
         # persist measurement dimensions
         if self.container_dimension_df:
             writer = storage_factory.create_container_dimension_writer()
@@ -708,6 +713,13 @@ class Report:
             merge_keys=["channel_id"],
         )
 
+        # Optional calculated channel metrics table (dynamic schema — merged
+        # directly, scoping the delete-by-source to updated containers).
+        self._persist_channel_metrics(
+            incremental=True,
+            updated_container_ids=updated_container_ids,
+        )
+
         # Persist the measurement dimension LAST (as ``_persist_full`` does). It
         # holds the gold timestamp that container-update detection compares
         # against; the fact solves above are lazy, so writing it earlier would
@@ -738,6 +750,72 @@ class Report:
                     solver_cfg.channel_alias_col,
                 ],
             )
+
+    def _persist_channel_metrics(
+        self,
+        *,
+        incremental: bool,
+        updated_container_ids: list | None = None,
+    ):
+        """Persist the optional calculated-channel metrics table(s).
+
+        The metrics schema is dynamic (identity/attribute columns vary per
+        report), so this bypasses the fixed-schema ``DefaultReportEntityWriter``
+        and stores the already-shaped DataFrame directly — mirroring the
+        ``container_dimension`` special-case. Full mode overwrites; incremental
+        mode upserts on ``(container_id, channel_id)`` and prunes stale rows from
+        updated containers via ``merge_incremental``.
+
+        Parameters
+        ----------
+        incremental : bool
+            Whether to merge (True) or overwrite (False).
+        updated_container_ids : list, optional
+            Ids of updated containers, scoping the incremental delete-by-source.
+        """
+        from functools import reduce
+
+        import pyspark.sql.functions as F
+
+        if not self.calculated_channel_metrics_dfs:
+            return
+
+        transformer = ReportEntityTransformer()
+        updated_container_ids = updated_container_ids or []
+
+        # Group per-type metrics dfs by output table (parallels persist_facts_*).
+        dfs_by_table: dict[str, list[DataFrame]] = {}
+        for type_name, dfs in self.calculated_channel_metrics_dfs.items():
+            if isinstance(dfs, dict):
+                candidates = [dfs.get(key) for key in ("changed", "unchanged")]
+            else:
+                candidates = [dfs]
+            table_dfs = [df for df in candidates if df is not None]
+            if not table_dfs:
+                continue
+            table_name = ChannelType[type_name].get_metrics_table_name()
+            dfs_by_table.setdefault(table_name, []).extend(table_dfs)
+
+        for table_name, dfs_list in dfs_by_table.items():
+            entity_type = ChannelType.get_any_for_metrics_table(table_name)
+            # Resolve the metrics URI directly (no fixed-schema writer).
+            uri = self.sink.config.get_output_uri_channel_metrics_table(entity_type)
+            combined = reduce(lambda a, b: a.unionByName(b), dfs_list)
+            df_enriched = combined.transform(transformer.add_meta_information)
+            if incremental:
+                delete_conditions = []
+                if updated_container_ids:
+                    delete_conditions.append(
+                        F.col("target.container_id").isin(updated_container_ids)
+                    )
+                self.sink.merge_incremental(
+                    df_enriched,
+                    uri,
+                    ["container_id", "channel_id"],
+                    delete_conditions=delete_conditions,
+                )
+            else:
+                self.sink.store(df_enriched, uri)
 
     def _transform_for_persistence(
         self,
@@ -1021,6 +1099,40 @@ class Report:
         self.calculated_channel_metadata_dfs = build_metadata_dfs(
             channels_by_type, ChannelType, self.spark
         )
+
+        # Optionally derive a silver-shaped channel_metrics table from the fact
+        # rows so the fact + metrics pair can serve as an Impulse silver source.
+        # Identity/attribute columns are derived dynamically; the full per-type
+        # channel list is passed to both buckets so changed/unchanged share a
+        # schema (extra channels are ignored by the fact-driven left join).
+        self.calculated_channel_metrics_dfs = {}
+        if self.config.calculated_channels.emit_channel_metrics:
+            attribute_columns = self.config.calculated_channels.attribute_columns
+            changed_metrics: dict = {}
+            unchanged_metrics: dict = {}
+            for type_name, full_channels in channels_by_type.items():
+                if not full_channels:
+                    continue
+                cls = ChannelType[type_name].value
+                changed_fact = changed_channel_dfs.get(type_name)
+                unchanged_fact = unchanged_channel_dfs.get(type_name)
+                if changed_fact is not None:
+                    changed_metrics[type_name] = cls.determine_channel_metrics(
+                        self.spark,
+                        full_channels,
+                        changed_fact,
+                        attribute_columns=attribute_columns,
+                    )
+                if unchanged_fact is not None:
+                    unchanged_metrics[type_name] = cls.determine_channel_metrics(
+                        self.spark,
+                        full_channels,
+                        unchanged_fact,
+                        attribute_columns=attribute_columns,
+                    )
+            self.calculated_channel_metrics_dfs = merge_changed_unchanged(
+                changed_metrics, unchanged_metrics
+            )
 
         # Determine container dimension
         self.container_dimension_df = ContainerDimension.get_dimension(

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -1108,6 +1108,7 @@ class Report:
         self.calculated_channel_metrics_dfs = {}
         if self.config.calculated_channels.emit_channel_metrics:
             attribute_columns = self.config.calculated_channels.attribute_columns
+            kpis = self.config.calculated_channels.kpis
             changed_metrics: dict = {}
             unchanged_metrics: dict = {}
             for type_name, full_channels in channels_by_type.items():
@@ -1122,6 +1123,7 @@ class Report:
                         full_channels,
                         changed_fact,
                         attribute_columns=attribute_columns,
+                        kpis=kpis,
                     )
                 if unchanged_fact is not None:
                     unchanged_metrics[type_name] = cls.determine_channel_metrics(
@@ -1129,6 +1131,7 @@ class Report:
                         full_channels,
                         unchanged_fact,
                         attribute_columns=attribute_columns,
+                        kpis=kpis,
                     )
             self.calculated_channel_metrics_dfs = merge_changed_unchanged(
                 changed_metrics, unchanged_metrics

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -25,6 +25,7 @@ from impulse_reporting.core.report_utils import (
     cleanup_temp_tables,
     collect_solvable_expressions,
     dispatch_aggregations,
+    dispatch_calculated_channel_metrics,
     dispatch_calculated_channels,
     dispatch_events,
     group_selectables_by_type,
@@ -1107,32 +1108,26 @@ class Report:
         # schema (extra channels are ignored by the fact-driven left join).
         self.calculated_channel_metrics_dfs = {}
         if self.config.calculated_channels.emit_channel_metrics:
-            attribute_columns = self.config.calculated_channels.attribute_columns
-            kpis = self.config.calculated_channels.kpis
-            changed_metrics: dict = {}
-            unchanged_metrics: dict = {}
-            for type_name, full_channels in channels_by_type.items():
-                if not full_channels:
-                    continue
-                cls = ChannelType[type_name].value
-                changed_fact = changed_channel_dfs.get(type_name)
-                unchanged_fact = unchanged_channel_dfs.get(type_name)
-                if changed_fact is not None:
-                    changed_metrics[type_name] = cls.determine_channel_metrics(
-                        self.spark,
-                        full_channels,
-                        changed_fact,
-                        attribute_columns=attribute_columns,
-                        kpis=kpis,
-                    )
-                if unchanged_fact is not None:
-                    unchanged_metrics[type_name] = cls.determine_channel_metrics(
-                        self.spark,
-                        full_channels,
-                        unchanged_fact,
-                        attribute_columns=attribute_columns,
-                        kpis=kpis,
-                    )
+            cc = self.config.calculated_channels
+            # Pass the full per-type channel list to both buckets so changed and
+            # unchanged metrics share one schema (extra channels are dropped by the
+            # fact-driven left join in determine_channel_metrics).
+            changed_metrics = dispatch_calculated_channel_metrics(
+                self.spark,
+                channels_by_type,
+                changed_channel_dfs,
+                ChannelType,
+                attribute_columns=cc.attribute_columns,
+                kpis=cc.kpis,
+            )
+            unchanged_metrics = dispatch_calculated_channel_metrics(
+                self.spark,
+                channels_by_type,
+                unchanged_channel_dfs,
+                ChannelType,
+                attribute_columns=cc.attribute_columns,
+                kpis=cc.kpis,
+            )
             self.calculated_channel_metrics_dfs = merge_changed_unchanged(
                 changed_metrics, unchanged_metrics
             )

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -28,9 +28,9 @@ from impulse_reporting.core.report_utils import (
     dispatch_calculated_channel_metrics,
     dispatch_calculated_channels,
     dispatch_events,
-    group_dfs_by_table,
     group_selectables_by_type,
     merge_changed_unchanged,
+    persist_channel_metrics,
     persist_dimensions_full,
     persist_dimensions_incremental,
     persist_facts_full,
@@ -603,7 +603,13 @@ class Report:
 
         # optional calculated channel metrics table (dynamic schema — stored
         # directly without the fixed-schema projecting writer)
-        self._persist_channel_metrics(incremental=False)
+        persist_channel_metrics(
+            self.calculated_channel_metrics_dfs,
+            ChannelType,
+            self.sink,
+            ReportEntityTransformer(),
+            incremental=False,
+        )
 
         # persist measurement dimensions
         if self.container_dimension_df:
@@ -717,7 +723,11 @@ class Report:
 
         # Optional calculated channel metrics table (dynamic schema — merged
         # directly, scoping the delete-by-source to updated containers).
-        self._persist_channel_metrics(
+        persist_channel_metrics(
+            self.calculated_channel_metrics_dfs,
+            ChannelType,
+            self.sink,
+            transformer,
             incremental=True,
             updated_container_ids=updated_container_ids,
         )
@@ -752,65 +762,6 @@ class Report:
                     solver_cfg.channel_alias_col,
                 ],
             )
-
-    def _persist_channel_metrics(
-        self,
-        *,
-        incremental: bool,
-        updated_container_ids: list | None = None,
-    ):
-        """Persist the optional calculated-channel metrics table(s).
-
-        The metrics schema is dynamic (identity/attribute columns vary per
-        report), so this bypasses the fixed-schema ``DefaultReportEntityWriter``
-        and stores the already-shaped DataFrame directly — mirroring the
-        ``container_dimension`` special-case. Full mode overwrites; incremental
-        mode upserts on ``(container_id, channel_id)`` and prunes stale rows from
-        updated containers via ``merge_incremental``.
-
-        Parameters
-        ----------
-        incremental : bool
-            Whether to merge (True) or overwrite (False).
-        updated_container_ids : list, optional
-            Ids of updated containers, scoping the incremental delete-by-source.
-        """
-        import pyspark.sql.functions as F
-
-        if not self.calculated_channel_metrics_dfs:
-            return
-
-        transformer = ReportEntityTransformer()
-        updated_container_ids = updated_container_ids or []
-
-        # Group per-type metrics dfs by output table and union each group 
-        # via the same ``concat_dataframes`` the entity writer uses.
-        dfs_by_table = group_dfs_by_table(
-            self.calculated_channel_metrics_dfs,
-            lambda type_name: ChannelType[type_name].get_metrics_table_name(),
-        )
-
-        for table_name, dfs_list in dfs_by_table.items():
-            entity_type = ChannelType.get_any_for_metrics_table(table_name)
-            # Resolve the metrics URI directly (no fixed-schema writer).
-            uri = self.sink.config.get_output_uri_channel_metrics_table(entity_type)
-            df_enriched = transformer.concat_dataframes(dfs_list).transform(
-                transformer.add_meta_information
-            )
-            if incremental:
-                delete_conditions = []
-                if updated_container_ids:
-                    delete_conditions.append(
-                        F.col("target.container_id").isin(updated_container_ids)
-                    )
-                self.sink.merge_incremental(
-                    df_enriched,
-                    uri,
-                    ["container_id", "channel_id"],
-                    delete_conditions=delete_conditions,
-                )
-            else:
-                self.sink.store(df_enriched, uri)
 
     def _transform_for_persistence(
         self,

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -28,6 +28,7 @@ from impulse_reporting.core.report_utils import (
     dispatch_calculated_channel_metrics,
     dispatch_calculated_channels,
     dispatch_events,
+    group_dfs_by_table,
     group_selectables_by_type,
     merge_changed_unchanged,
     persist_dimensions_full,
@@ -774,8 +775,6 @@ class Report:
         updated_container_ids : list, optional
             Ids of updated containers, scoping the incremental delete-by-source.
         """
-        from functools import reduce
-
         import pyspark.sql.functions as F
 
         if not self.calculated_channel_metrics_dfs:
@@ -784,25 +783,20 @@ class Report:
         transformer = ReportEntityTransformer()
         updated_container_ids = updated_container_ids or []
 
-        # Group per-type metrics dfs by output table (parallels persist_facts_*).
-        dfs_by_table: dict[str, list[DataFrame]] = {}
-        for type_name, dfs in self.calculated_channel_metrics_dfs.items():
-            if isinstance(dfs, dict):
-                candidates = [dfs.get(key) for key in ("changed", "unchanged")]
-            else:
-                candidates = [dfs]
-            table_dfs = [df for df in candidates if df is not None]
-            if not table_dfs:
-                continue
-            table_name = ChannelType[type_name].get_metrics_table_name()
-            dfs_by_table.setdefault(table_name, []).extend(table_dfs)
+        # Group per-type metrics dfs by output table and union each group 
+        # via the same ``concat_dataframes`` the entity writer uses.
+        dfs_by_table = group_dfs_by_table(
+            self.calculated_channel_metrics_dfs,
+            lambda type_name: ChannelType[type_name].get_metrics_table_name(),
+        )
 
         for table_name, dfs_list in dfs_by_table.items():
             entity_type = ChannelType.get_any_for_metrics_table(table_name)
             # Resolve the metrics URI directly (no fixed-schema writer).
             uri = self.sink.config.get_output_uri_channel_metrics_table(entity_type)
-            combined = reduce(lambda a, b: a.unionByName(b), dfs_list)
-            df_enriched = combined.transform(transformer.add_meta_information)
+            df_enriched = transformer.concat_dataframes(dfs_list).transform(
+                transformer.add_meta_information
+            )
             if incremental:
                 delete_conditions = []
                 if updated_container_ids:

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -619,6 +619,43 @@ def _fact_dfs_for_table(dfs) -> list[DataFrame]:
     return [dfs] if dfs is not None else []
 
 
+def group_dfs_by_table(
+    dfs_by_type: dict,
+    table_name_getter: Callable[[str], str],
+) -> dict[str, list[DataFrame]]:
+    """Group per-type DataFrames by output table name.
+
+    Shared shaping step for the "write one table per output" persistence paths:
+    flattens each per-type value (a ``{"changed", "unchanged"}`` dict or a bare
+    DataFrame, via :func:`_fact_dfs_for_table`) and buckets the DataFrames by the
+    table name that ``table_name_getter`` returns for the type (so types sharing a
+    table land together). Types that contribute no DataFrame are skipped, so every
+    returned list is non-empty. Callers union each list themselves (e.g. via
+    ``ReportEntityTransformer.concat_dataframes`` / the entity writer).
+
+    Parameters
+    ----------
+    dfs_by_type : dict
+        ``{type_name: value}`` where value is a structured
+        ``{"changed", "unchanged"}`` dict or a bare DataFrame.
+    table_name_getter : Callable[[str], str]
+        Maps a type name to its output table name (e.g.
+        ``lambda t: ChannelType[t].get_metrics_table_name()``).
+
+    Returns
+    -------
+    dict[str, list[DataFrame]]
+        ``{table_name: [dfs]}`` for each table with at least one DataFrame.
+    """
+    dfs_by_table: dict[str, list[DataFrame]] = {}
+    for type_name, dfs in dfs_by_type.items():
+        table_dfs = _fact_dfs_for_table(dfs)
+        if not table_dfs:
+            continue
+        dfs_by_table.setdefault(table_name_getter(type_name), []).extend(table_dfs)
+    return dfs_by_table
+
+
 def persist_facts_full(dfs_by_type: dict, type_enum, writer_factory: WriterFactory) -> None:
     """Full-overwrite persist of fact DataFrames, grouped by output table.
 
@@ -635,14 +672,11 @@ def persist_facts_full(dfs_by_type: dict, type_enum, writer_factory: WriterFacto
     writer_factory : WriterFactory
         Factory producing the entity writer.
     """
-    dfs_by_table: dict[str, list[DataFrame]] = {}
-    for type_name, dfs in dfs_by_type.items():
-        table_name = type_enum[type_name].get_fact_table_name()
-        dfs_by_table.setdefault(table_name, []).extend(_fact_dfs_for_table(dfs))
+    dfs_by_table = group_dfs_by_table(
+        dfs_by_type, lambda type_name: type_enum[type_name].get_fact_table_name()
+    )
 
     for table_name, dfs_list in dfs_by_table.items():
-        if not dfs_list:
-            continue
         entity_type = type_enum.get_any_for_fact_table(table_name)
         writer = writer_factory.create_writer(entity_type)
         schema, uri = writer.extract_fact_schema_and_output_uri(entity_type)

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -26,7 +26,11 @@ if TYPE_CHECKING:
     from impulse_reporting.incremental.definition_hash_comparator import (
         DefinitionHashComparator,
     )
-    from impulse_reporting.persist.report_storage import Sink, WriterFactory
+    from impulse_reporting.persist.report_storage import (
+        ReportEntityTransformer,
+        Sink,
+        WriterFactory,
+    )
 
 
 def build_batches(
@@ -859,3 +863,71 @@ def persist_dimensions_incremental(
         writer = factory.create_writer(entity_type)
         schema, uri = writer.extract_metadata_schema_and_output_uri(entity_type)
         sink.upsert(transform_fn(metadata_df, schema), uri, merge_keys)
+
+
+def persist_channel_metrics(
+    metrics_dfs_by_type: dict,
+    type_enum,
+    sink: Sink,
+    transformer: ReportEntityTransformer,
+    *,
+    incremental: bool,
+    updated_container_ids: list | None = None,
+) -> None:
+    """Persist the optional calculated-channel metrics table(s).
+
+    Unlike the fact/dimension writers, the metrics schema is **dynamic**
+    (identity/attribute/KPI columns vary per report), so this bypasses the
+    fixed-schema ``DefaultReportEntityWriter`` and writes the already-shaped
+    DataFrame directly (mirroring the ``container_dimension`` special-case). The
+    per-type dfs are grouped by output table via :func:`group_dfs_by_table` and
+    unioned with the same ``concat_dataframes`` the entity writer uses.
+
+    Full mode overwrites; incremental mode upserts on ``(container_id,
+    channel_id)`` and prunes stale rows from updated containers via
+    ``merge_incremental``.
+
+    Parameters
+    ----------
+    metrics_dfs_by_type : dict
+        ``{type_name: value}`` where value is a structured
+        ``{"changed", "unchanged"}`` dict or a bare DataFrame.
+    type_enum : Enum
+        The channel type-enum (resolves the metrics table name/uri).
+    sink : Sink
+        Target sink exposing ``store`` / ``merge_incremental``.
+    transformer : ReportEntityTransformer
+        Supplies ``concat_dataframes`` (union) and ``add_meta_information``.
+    incremental : bool
+        Whether to merge (True) or overwrite (False).
+    updated_container_ids : list, optional
+        Ids of updated containers, scoping the incremental delete-by-source.
+    """
+    if not metrics_dfs_by_type:
+        return
+
+    updated_container_ids = updated_container_ids or []
+
+    dfs_by_table = group_dfs_by_table(
+        metrics_dfs_by_type, lambda type_name: type_enum[type_name].get_metrics_table_name()
+    )
+
+    for table_name, dfs_list in dfs_by_table.items():
+        entity_type = type_enum.get_any_for_metrics_table(table_name)
+        # Resolve the metrics URI directly (no fixed-schema writer).
+        uri = sink.config.get_output_uri_channel_metrics_table(entity_type)
+        df_enriched = transformer.concat_dataframes(dfs_list).transform(
+            transformer.add_meta_information
+        )
+        if incremental:
+            delete_conditions = []
+            if updated_container_ids:
+                delete_conditions.append(F.col("target.container_id").isin(updated_container_ids))
+            sink.merge_incremental(
+                df_enriched,
+                uri,
+                ["container_id", "channel_id"],
+                delete_conditions=delete_conditions,
+            )
+        else:
+            sink.store(df_enriched, uri)

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -350,6 +350,66 @@ def dispatch_calculated_channels(
     return channel_dfs
 
 
+def dispatch_calculated_channel_metrics(
+    spark: SparkSession,
+    channels_by_type: dict[str, list],
+    fact_dfs_by_type: dict[str, DataFrame | None],
+    type_enum,
+    *,
+    attribute_columns: list[str],
+    kpis: list[str],
+) -> dict:
+    """Dispatch ``determine_channel_metrics`` calls per type.
+
+    Post-processing counterpart to :func:`dispatch_calculated_channels`: instead
+    of solving, it derives the silver-shaped ``channel_metrics`` DataFrame from the
+    already-solved fact df for each type (``fact_dfs_by_type`` as returned by
+    :func:`dispatch_calculated_channels`).
+
+    Pass the **full** per-type channel list (not a changed/unchanged split): the
+    metrics aggregation is fact-driven (a left join from the fact-derived
+    aggregate), so channels absent from ``fact_df`` are dropped, while the identity
+    columns are the union across all channels — keeping the changed and unchanged
+    metrics dfs on an identical schema for the downstream ``unionByName`` MERGE.
+
+    Parameters
+    ----------
+    spark : SparkSession
+    channels_by_type : dict[str, list]
+        Full per-type channel list.
+    fact_dfs_by_type : dict[str, DataFrame | None]
+        Per-type calculated-channel fact df for this bucket (changed or unchanged).
+    type_enum : ChannelType enum
+    attribute_columns : list[str]
+        Attribute keys to surface as columns.
+    kpis : list[str]
+        KPI names to compute.
+
+    Returns
+    -------
+    dict
+        ``metrics_dfs`` keyed by type name (only types with a fact df).
+    """
+    metrics_dfs: dict = {}
+
+    for type_name, channels in channels_by_type.items():
+        if not channels:
+            continue
+        fact_df = fact_dfs_by_type.get(type_name)
+        if fact_df is None:
+            continue
+        cls = type_enum[type_name].value
+        metrics_dfs[type_name] = cls.determine_channel_metrics(
+            spark,
+            channels,
+            fact_df,
+            attribute_columns=attribute_columns,
+            kpis=kpis,
+        )
+
+    return metrics_dfs
+
+
 def solve_expressions_batched(
     spark: SparkSession,
     expressions: list[TimeSeriesExpression],

--- a/src/impulse_reporting/persist/report_storage.py
+++ b/src/impulse_reporting/persist/report_storage.py
@@ -86,6 +86,23 @@ class SinkConfig(ABC):
         """
         pass
 
+    @abstractmethod
+    def get_output_uri_channel_metrics_table(self, element: ChannelType) -> str:
+        """
+        Get the output URI for the (optional) channel-metrics table.
+
+        Parameters
+        ----------
+        element : ChannelType
+            The channel type to get the URI for.
+
+        Returns
+        -------
+        str
+            The output URI for the channel-metrics table.
+        """
+        pass
+
 
 @dataclass()
 class UnitySinkConfig(SinkConfig):
@@ -183,6 +200,27 @@ class UnitySinkConfig(SinkConfig):
             )
         else:
             uri = f"{self.catalog_name}.{self.schema_name}." "channel_mapping_resolution_dimension"
+        return uri
+
+    def get_output_uri_channel_metrics_table(self, element: ChannelType) -> str:
+        """
+        Get the output URI for the channel-metrics table in Unity Catalog format.
+
+        Parameters
+        ----------
+        element : ChannelType
+            The channel type to get the URI for.
+
+        Returns
+        -------
+        str
+            The Unity Catalog URI for the channel-metrics table.
+        """
+        table_name = element.get_metrics_table_name()
+        if self.table_prefix:
+            uri = f"{self.catalog_name}.{self.schema_name}.{self.table_prefix}_{table_name}"
+        else:
+            uri = f"{self.catalog_name}.{self.schema_name}.{table_name}"
         return uri
 
 

--- a/tests/impulse_reporting/integration/calculated_channel_test.py
+++ b/tests/impulse_reporting/integration/calculated_channel_test.py
@@ -515,3 +515,30 @@ def test_channel_metrics_incremental_is_idempotent(spark):
     r2.persist_results()
 
     assert spark.read.table(_METRICS).count() == count_before
+
+
+def test_channel_metrics_custom_kpis(spark):
+    # A non-default KPI selection controls which KPI columns are emitted.
+    report = Report(
+        name="calc_channel_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(
+            _config(
+                is_enabled=False,
+                calculated_channels=CalculatedChannels(
+                    emit_channel_metrics=True, kpis=["min", "max"]
+                ),
+            )
+        ),
+    )
+    _add_channel(report, factor=3.6)
+    report.determine_report()
+    report.persist_results()
+
+    metrics = spark.read.table(_METRICS)
+    # Only the selected KPIs are present; the dropped defaults are absent.
+    assert "min" in metrics.columns
+    assert "max" in metrics.columns
+    assert "mean" not in metrics.columns
+    assert "duration" not in metrics.columns

--- a/tests/impulse_reporting/integration/calculated_channel_test.py
+++ b/tests/impulse_reporting/integration/calculated_channel_test.py
@@ -266,12 +266,16 @@ def test_incremental_modified_container_fewer_rows_deletes_stale(spark):
 
 
 def test_incremental_changed_definition_replaces(spark):
+    # Metrics enabled so this also covers a changed-definition refresh of the
+    # metrics table (no extra Report runs / no added suite time).
+    cc = CalculatedChannels(emit_channel_metrics=True)
+
     # Seed gold with factor 3.6.
     r1 = Report(
         name="calc_channel_report",
         spark=spark,
         workspace_client=create_autospec(WorkspaceClient),
-        config=dict(_config(is_enabled=False)),
+        config=dict(_config(is_enabled=False, calculated_channels=cc)),
     )
     ch1 = _add_channel(r1, factor=3.6)
     r1.determine_report()
@@ -282,6 +286,12 @@ def test_incremental_changed_definition_replaces(spark):
         .select("definition_hash")
         .first()[0]
     )
+    # Metric mean under the 3.6 definition (container 1), captured before the change.
+    mean_before = (
+        spark.read.table(_METRICS)
+        .filter((F.col("channel_id") == ch1.get_id()) & (F.col("container_id") == 1))
+        .first()["mean"]
+    )
 
     # Re-run incrementally with a changed factor → the changed-definition path
     # rewrites the rows in the unified MERGE (scoped by channel_id).
@@ -289,7 +299,7 @@ def test_incremental_changed_definition_replaces(spark):
         name="calc_channel_report",
         spark=spark,
         workspace_client=create_autospec(WorkspaceClient),
-        config=dict(_config(is_enabled=True)),
+        config=dict(_config(is_enabled=True, calculated_channels=cc)),
     )
     ch2 = _add_channel(r2, factor=3.7)
     assert ch2.get_id() == ch1.get_id()  # same identity → same entity id
@@ -303,6 +313,16 @@ def test_incremental_changed_definition_replaces(spark):
     assert hash_after != hash_before
     # A single dimension row per channel_id (upsert, not append).
     assert dim.filter(F.col("channel_id") == ch2.get_id()).count() == 1
+
+    # The metrics row was recomputed for the changed definition: the signal is
+    # `Vehicle Speed Sensor * factor`, so its duration-weighted mean scales
+    # linearly with the factor (3.6 → 3.7).
+    mean_after = (
+        spark.read.table(_METRICS)
+        .filter((F.col("channel_id") == ch2.get_id()) & (F.col("container_id") == 1))
+        .first()["mean"]
+    )
+    assert mean_after == pytest.approx(mean_before * 3.7 / 3.6)
 
 
 def test_incremental_identity_reorder_does_not_reprocess(spark):
@@ -459,6 +479,26 @@ def test_channel_metrics_emitted_and_usable_as_impulse_source(spark):
     fact = spark.read.table(_FACT)
     n_pairs = fact.select("container_id", "channel_id").distinct().count()
     assert metrics.count() == n_pairs
+
+    # Numeric KPIs match a hand-computed, duration-weighted aggregate of the gold
+    # fact rows (container 1). Independently reproduces the production semantics so
+    # a regression in the KPI math is caught end to end.
+    fact_rows = (
+        fact.filter((F.col("channel_id") == ch.get_id()) & (F.col("container_id") == 1))
+        .select("tstart", "tend", "value")
+        .collect()
+    )
+    durations = [r["tend"] - r["tstart"] for r in fact_rows]
+    values = [r["value"] for r in fact_rows]
+    exp_duration = max(r["tend"] for r in fact_rows) - min(r["tstart"] for r in fact_rows)
+    exp_mean = sum(v * d for v, d in zip(values, durations, strict=True)) / sum(durations)
+    m_row = metrics.filter(
+        (F.col("channel_id") == ch.get_id()) & (F.col("container_id") == 1)
+    ).first()
+    assert m_row["duration"] == exp_duration
+    assert m_row["min"] == pytest.approx(min(values))
+    assert m_row["max"] == pytest.approx(max(values))
+    assert m_row["mean"] == pytest.approx(exp_mean)
 
     # Round-trip: the fact + metrics pair is a valid Impulse silver source. Feed
     # them back as `channels` + `channel_metrics` (wide model: channel_name is a

--- a/tests/impulse_reporting/integration/calculated_channel_test.py
+++ b/tests/impulse_reporting/integration/calculated_channel_test.py
@@ -14,8 +14,10 @@ import pyspark.sql.types as T
 import pytest
 from databricks.sdk import WorkspaceClient
 
+from impulse_query_engine.measurement_db import MeasurementDB, MeasurementDBConfig
 from impulse_reporting.channels.calculated_channel import CalculatedChannel
 from impulse_reporting.config.config_parser import (
+    CalculatedChannels,
     DataType,
     ImpulseConfig,
     IncrementalConfig,
@@ -31,10 +33,11 @@ from tests.impulse_reporting.integration.test_helpers import (
 
 _FACT = "spark_catalog.gold.evaluation_calculated_channel_fact"
 _DIM = "spark_catalog.gold.evaluation_calculated_channel_dimension"
+_METRICS = "spark_catalog.gold.evaluation_calculated_channel_metrics"
 
 
-def _config(silver_table="container_metrics", is_enabled=False):
-    return ImpulseConfig(
+def _config(silver_table="container_metrics", is_enabled=False, calculated_channels=None):
+    kwargs = dict(
         source=Source(
             container_metrics_table=f"spark_catalog.silver.{silver_table}",
             channel_metrics_table="spark_catalog.silver.channel_metrics",
@@ -51,6 +54,9 @@ def _config(silver_table="container_metrics", is_enabled=False):
             gold_last_modified_column="_created_at",
         ),
     )
+    if calculated_channels is not None:
+        kwargs["calculated_channels"] = calculated_channels
+    return ImpulseConfig(**kwargs)
 
 
 def _add_channel(report, factor=3.6, name="speed_kmh", identity=None):
@@ -380,3 +386,132 @@ def test_calculated_channel_raw_mode(spark, setup_raw_channels_db):
     assert "identity" not in df.columns
     ids = {r["channel_id"] for r in df.select("channel_id").distinct().collect()}
     assert ids == {ch.get_id()}
+
+
+def test_channel_metrics_not_emitted_by_default(spark):
+    # Flag off (default) → no calculated_channel_metrics table is written even
+    # when channels carry attributes.
+    report = Report(
+        name="calc_channel_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(_config(is_enabled=False)),
+    )
+    _add_channel(report, factor=3.6)
+    report.determine_report()
+    report.persist_results()
+
+    assert spark.catalog.tableExists(_FACT)
+    assert not spark.catalog.tableExists(_METRICS)
+
+
+def test_channel_metrics_emitted_and_usable_as_impulse_source(spark):
+    # Opt in to the metrics table, with `unit` surfaced as an attribute column.
+    report = Report(
+        name="calc_channel_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(
+            _config(
+                is_enabled=False,
+                calculated_channels=CalculatedChannels(
+                    emit_channel_metrics=True, attribute_columns=["unit"]
+                ),
+            )
+        ),
+    )
+    q = report.get_db().query
+    ch = CalculatedChannel(
+        name="speed_kmh",
+        expr=q.channel(channel_name="Vehicle Speed Sensor") * 3.6,
+        identity={"channel_name": "speed_kmh", "data_key": "CALC"},
+        attributes={"unit": "km/h"},
+    )
+    report.add_calculated_channel(ch)
+
+    report.determine_report()
+    report.persist_results()
+
+    assert spark.catalog.tableExists(_METRICS)
+    metrics = spark.read.table(_METRICS)
+    # Dynamic identity columns (channel_name, data_key) + configured attribute (unit)
+    # + fixed metric columns; identity keys always present, attribute opt-in.
+    for col in [
+        "container_id",
+        "channel_id",
+        "channel_name",
+        "data_key",
+        "unit",
+        "type",
+        "data_type",
+        "duration",
+        "min",
+        "max",
+        "mean",
+    ]:
+        assert col in metrics.columns, col
+
+    row = metrics.filter(F.col("channel_id") == ch.get_id()).first()
+    assert row["type"] == "CALC"
+    assert row["data_type"] == "double"
+    assert row["channel_name"] == "speed_kmh"
+    assert row["data_key"] == "CALC"
+    assert row["unit"] == "km/h"
+    # One metrics row per (container, channel).
+    fact = spark.read.table(_FACT)
+    n_pairs = fact.select("container_id", "channel_id").distinct().count()
+    assert metrics.count() == n_pairs
+
+    # Round-trip: the fact + metrics pair is a valid Impulse silver source. Feed
+    # them back as `channels` + `channel_metrics` (wide model: channel_name is a
+    # column on channel_metrics) and resolve the channel by name. A minimal
+    # `container_metrics` (one row per container) satisfies the filter pipeline.
+    fact_as_channels = spark.read.table(_FACT).select(
+        "container_id", "channel_id", "tstart", "tend", "value"
+    )
+    container_metrics = fact_as_channels.select("container_id").distinct()
+    db = MeasurementDB(
+        MeasurementDBConfig.for_debug(
+            {
+                "channels": fact_as_channels,
+                "channel_metrics": metrics,
+                "container_metrics": container_metrics,
+            }
+        ),
+        ws=report.ws,
+    )
+    solved = (
+        db.query.channel(channel_name="speed_kmh").alias("v").solve(spark, report.get_solver())
+    )
+    assert solved.count() > 0
+
+
+def test_channel_metrics_incremental_is_idempotent(spark):
+    # Seed gold (full) with the metrics table, then re-run incrementally with the
+    # same definition/data: the metrics upsert on (container_id, channel_id) must
+    # keep the row count stable (one row per container/channel).
+    cc = CalculatedChannels(emit_channel_metrics=True)
+
+    r1 = Report(
+        name="calc_channel_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(_config(is_enabled=False, calculated_channels=cc)),
+    )
+    _add_channel(r1, factor=3.6)
+    r1.determine_report()
+    r1.persist_results()
+    count_before = spark.read.table(_METRICS).count()
+    assert count_before > 0
+
+    r2 = Report(
+        name="calc_channel_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(_config(is_enabled=True, calculated_channels=cc)),
+    )
+    _add_channel(r2, factor=3.6)
+    r2.determine_report()
+    r2.persist_results()
+
+    assert spark.read.table(_METRICS).count() == count_before

--- a/tests/impulse_reporting/integration/calculated_channel_test.py
+++ b/tests/impulse_reporting/integration/calculated_channel_test.py
@@ -442,7 +442,6 @@ def test_channel_metrics_emitted_and_usable_as_impulse_source(spark):
         "channel_name",
         "data_key",
         "unit",
-        "type",
         "data_type",
         "duration",
         "min",
@@ -452,7 +451,6 @@ def test_channel_metrics_emitted_and_usable_as_impulse_source(spark):
         assert col in metrics.columns, col
 
     row = metrics.filter(F.col("channel_id") == ch.get_id()).first()
-    assert row["type"] == "CALC"
     assert row["data_type"] == "double"
     assert row["channel_name"] == "speed_kmh"
     assert row["data_key"] == "CALC"

--- a/tests/impulse_reporting/integration/calculated_channel_test.py
+++ b/tests/impulse_reporting/integration/calculated_channel_test.py
@@ -442,7 +442,7 @@ def test_channel_metrics_emitted_and_usable_as_impulse_source(spark):
         "channel_name",
         "data_key",
         "unit",
-        "data_type",
+        "value_type",
         "duration",
         "min",
         "max",
@@ -451,7 +451,7 @@ def test_channel_metrics_emitted_and_usable_as_impulse_source(spark):
         assert col in metrics.columns, col
 
     row = metrics.filter(F.col("channel_id") == ch.get_id()).first()
-    assert row["data_type"] == "double"
+    assert row["value_type"] == "double"
     assert row["channel_name"] == "speed_kmh"
     assert row["data_key"] == "CALC"
     assert row["unit"] == "km/h"

--- a/tests/impulse_reporting/unit/channels/calculated_channel_test.py
+++ b/tests/impulse_reporting/unit/channels/calculated_channel_test.py
@@ -199,7 +199,7 @@ class TestDetermineChannelMetrics:
         r = rows[0]
         assert r["container_id"] == 1
         assert r["channel_id"] == cid
-        assert r["data_type"] == "double"
+        assert r["value_type"] == "double"
         assert r["duration"] == 3  # max(tend) - min(tstart) = 3 - 0
         assert r["min"] == 10.0
         assert r["max"] == 20.0
@@ -293,7 +293,7 @@ class TestDetermineChannelMetrics:
             "container_id",
             "channel_id",
             "channel_name",
-            "data_type",
+            "value_type",
             "duration",
             "min",
             "max",
@@ -318,7 +318,7 @@ class TestDetermineChannelMetrics:
 
     def test_kpis_subset_only_emits_selected(self, spark):
         # Selecting a subset yields only those KPI columns (plus the fixed
-        # container/channel/identity/data_type columns).
+        # container/channel/identity/value_type columns).
         ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
         fact = spark.createDataFrame([(1, ch.get_id(), 0, 2, 10.0)], schema=_FACT_SCHEMA)
         out = CalculatedChannel.determine_channel_metrics(
@@ -328,7 +328,7 @@ class TestDetermineChannelMetrics:
             "container_id",
             "channel_id",
             "channel_name",
-            "data_type",
+            "value_type",
             "mean",
         ]
         assert out.collect()[0]["mean"] == pytest.approx(10.0)

--- a/tests/impulse_reporting/unit/channels/calculated_channel_test.py
+++ b/tests/impulse_reporting/unit/channels/calculated_channel_test.py
@@ -199,7 +199,6 @@ class TestDetermineChannelMetrics:
         r = rows[0]
         assert r["container_id"] == 1
         assert r["channel_id"] == cid
-        assert r["type"] == "CALC"
         assert r["data_type"] == "double"
         assert r["duration"] == 3  # max(tend) - min(tstart) = 3 - 0
         assert r["min"] == 10.0
@@ -294,7 +293,6 @@ class TestDetermineChannelMetrics:
             "container_id",
             "channel_id",
             "channel_name",
-            "type",
             "data_type",
             "duration",
             "min",
@@ -320,7 +318,7 @@ class TestDetermineChannelMetrics:
 
     def test_kpis_subset_only_emits_selected(self, spark):
         # Selecting a subset yields only those KPI columns (plus the fixed
-        # container/channel/identity/type/data_type columns).
+        # container/channel/identity/data_type columns).
         ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
         fact = spark.createDataFrame([(1, ch.get_id(), 0, 2, 10.0)], schema=_FACT_SCHEMA)
         out = CalculatedChannel.determine_channel_metrics(
@@ -330,7 +328,6 @@ class TestDetermineChannelMetrics:
             "container_id",
             "channel_id",
             "channel_name",
-            "type",
             "data_type",
             "mean",
         ]

--- a/tests/impulse_reporting/unit/channels/calculated_channel_test.py
+++ b/tests/impulse_reporting/unit/channels/calculated_channel_test.py
@@ -223,6 +223,24 @@ class TestDetermineChannelMetrics:
         # (10*1) / (1+1) = 5.0
         assert r["mean"] == pytest.approx(5.0)
 
+    def test_zero_total_duration_mean_is_null_not_error(self, spark):
+        # A group of only zero-duration point-in-time samples (tstart == tend) has
+        # sum(dur) == 0. Under ANSI mode (Spark 4.0 default) plain division would
+        # raise DIVIDE_BY_ZERO; try_divide yields a null mean instead.
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        cid = ch.get_id()
+        fact = spark.createDataFrame(
+            [(1, cid, 5, 5, 10.0), (1, cid, 7, 7, 20.0)], schema=_FACT_SCHEMA
+        )
+        r = CalculatedChannel.determine_channel_metrics(
+            spark, [ch], fact, attribute_columns=[]
+        ).collect()[0]
+        assert r["duration"] == 2  # max(tend) - min(tstart) = 7 - 5
+        assert r["mean"] is None
+        # min/max still resolve from the values.
+        assert r["min"] == 10.0
+        assert r["max"] == 20.0
+
     def test_dynamic_identity_columns_union(self, spark):
         # Two channels with DIFFERENT identity keys → output has the union, null
         # where a channel omits a key.
@@ -299,3 +317,45 @@ class TestDetermineChannelMetrics:
         )
         assert out.columns.count("unit") == 1
         assert out.collect()[0]["unit"] == "identity_unit"
+
+    def test_kpis_subset_only_emits_selected(self, spark):
+        # Selecting a subset yields only those KPI columns (plus the fixed
+        # container/channel/identity/type/data_type columns).
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        fact = spark.createDataFrame([(1, ch.get_id(), 0, 2, 10.0)], schema=_FACT_SCHEMA)
+        out = CalculatedChannel.determine_channel_metrics(
+            spark, [ch], fact, attribute_columns=[], kpis=["mean"]
+        )
+        assert out.columns == [
+            "container_id",
+            "channel_id",
+            "channel_name",
+            "type",
+            "data_type",
+            "mean",
+        ]
+        assert out.collect()[0]["mean"] == pytest.approx(10.0)
+
+    def test_kpis_order_is_preserved(self, spark):
+        # The KPI columns appear in the configured order (tail of the schema).
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        fact = spark.createDataFrame([(1, ch.get_id(), 0, 2, 10.0)], schema=_FACT_SCHEMA)
+        out = CalculatedChannel.determine_channel_metrics(
+            spark, [ch], fact, attribute_columns=[], kpis=["max", "min", "duration"]
+        )
+        assert out.columns[-3:] == ["max", "min", "duration"]
+
+    def test_kpis_default_is_the_four(self, spark):
+        # kpis=None → default duration, min, max, mean (in order).
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        fact = spark.createDataFrame([(1, ch.get_id(), 0, 2, 10.0)], schema=_FACT_SCHEMA)
+        out = CalculatedChannel.determine_channel_metrics(spark, [ch], fact, attribute_columns=[])
+        assert out.columns[-4:] == ["duration", "min", "max", "mean"]
+
+    def test_unknown_kpi_raises(self, spark):
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        fact = spark.createDataFrame([(1, ch.get_id(), 0, 2, 10.0)], schema=_FACT_SCHEMA)
+        with pytest.raises(ValueError, match="Unknown calculated-channel KPI"):
+            CalculatedChannel.determine_channel_metrics(
+                spark, [ch], fact, attribute_columns=[], kpis=["bogus"]
+            )

--- a/tests/impulse_reporting/unit/channels/calculated_channel_test.py
+++ b/tests/impulse_reporting/unit/channels/calculated_channel_test.py
@@ -2,6 +2,7 @@
 """Unit tests for the reporting-layer CalculatedChannel class."""
 
 import pytest
+import pyspark.sql.types as T
 
 from impulse_query_engine.analyze.metadata.time_series_expression import TimeSeriesSelector
 from impulse_query_engine.analyze.query.solvers.default_solver import DefaultSolver
@@ -164,3 +165,137 @@ class TestDetermineCalculatedChannels:
         ]
         ids = {r["channel_id"] for r in df.select("channel_id").distinct().collect()}
         assert ids == {ch.get_id()}
+
+
+_FACT_SCHEMA = T.StructType(
+    [
+        T.StructField("container_id", T.LongType(), False),
+        T.StructField("channel_id", T.LongType(), False),
+        T.StructField("tstart", T.LongType(), False),
+        T.StructField("tend", T.LongType(), False),
+        T.StructField("value", T.DoubleType(), True),
+    ]
+)
+
+
+class TestDetermineChannelMetrics:
+    def test_returns_none_when_fact_none(self, spark):
+        assert (
+            CalculatedChannel.determine_channel_metrics(spark, [], None, attribute_columns=[])
+            is None
+        )
+
+    def test_duration_weighted_values(self, spark):
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        cid = ch.get_id()
+        # Two intervals with different durations: [0,1) value 10, [1,3) value 20.
+        # duration-weighted mean = (10*1 + 20*2) / (1+2) = 50/3.
+        fact = spark.createDataFrame(
+            [(1, cid, 0, 1, 10.0), (1, cid, 1, 3, 20.0)], schema=_FACT_SCHEMA
+        )
+        out = CalculatedChannel.determine_channel_metrics(spark, [ch], fact, attribute_columns=[])
+        rows = out.collect()
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["container_id"] == 1
+        assert r["channel_id"] == cid
+        assert r["type"] == "CALC"
+        assert r["data_type"] == "double"
+        assert r["duration"] == 3  # max(tend) - min(tstart) = 3 - 0
+        assert r["min"] == 10.0
+        assert r["max"] == 20.0
+        assert r["mean"] == pytest.approx(50.0 / 3.0)
+        assert r["channel_name"] == "s"
+
+    def test_nan_values_ignored_in_min_max_mean(self, spark):
+        ch = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"})
+        cid = ch.get_id()
+        # [0,1) value 10, [1,2) NaN → NaN excluded from min/max/weighted-sum, but its
+        # duration still counts in the denominator (matches SampleSeries.mean).
+        fact = spark.createDataFrame(
+            [(1, cid, 0, 1, 10.0), (1, cid, 1, 2, float("nan"))], schema=_FACT_SCHEMA
+        )
+        r = CalculatedChannel.determine_channel_metrics(
+            spark, [ch], fact, attribute_columns=[]
+        ).collect()[0]
+        assert r["min"] == 10.0
+        assert r["max"] == 10.0
+        # (10*1) / (1+1) = 5.0
+        assert r["mean"] == pytest.approx(5.0)
+
+    def test_dynamic_identity_columns_union(self, spark):
+        # Two channels with DIFFERENT identity keys → output has the union, null
+        # where a channel omits a key.
+        ch1 = CalculatedChannel("a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s1"})
+        ch2 = CalculatedChannel(
+            "b", TimeSeriesSelector(None) * 1.0, {"channel_name": "s2", "data_key": "K"}
+        )
+        fact = spark.createDataFrame(
+            [(1, ch1.get_id(), 0, 1, 1.0), (1, ch2.get_id(), 0, 1, 2.0)],
+            schema=_FACT_SCHEMA,
+        )
+        out = CalculatedChannel.determine_channel_metrics(
+            spark, [ch1, ch2], fact, attribute_columns=[]
+        )
+        assert "channel_name" in out.columns
+        assert "data_key" in out.columns
+        by_id = {r["channel_id"]: r for r in out.collect()}
+        assert by_id[ch1.get_id()]["channel_name"] == "s1"
+        assert by_id[ch1.get_id()]["data_key"] is None  # ch1 has no data_key
+        assert by_id[ch2.get_id()]["data_key"] == "K"
+
+    def test_attribute_columns_config_selected(self, spark):
+        # A configured attribute key surfaces as a column; unconfigured attributes
+        # do not. A channel omitting the key gets null.
+        ch1 = CalculatedChannel(
+            "a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s1"}, attributes={"unit": "kmh"}
+        )
+        ch2 = CalculatedChannel(
+            "b", TimeSeriesSelector(None) * 1.0, {"channel_name": "s2"}, attributes={"scale": "2"}
+        )
+        fact = spark.createDataFrame(
+            [(1, ch1.get_id(), 0, 1, 1.0), (1, ch2.get_id(), 0, 1, 2.0)],
+            schema=_FACT_SCHEMA,
+        )
+        out = CalculatedChannel.determine_channel_metrics(
+            spark, [ch1, ch2], fact, attribute_columns=["unit"]
+        )
+        assert "unit" in out.columns
+        assert "scale" not in out.columns  # not configured
+        by_id = {r["channel_id"]: r for r in out.collect()}
+        assert by_id[ch1.get_id()]["unit"] == "kmh"
+        assert by_id[ch2.get_id()]["unit"] is None
+
+    def test_no_attribute_columns_by_default(self, spark):
+        ch = CalculatedChannel(
+            "a", TimeSeriesSelector(None) * 1.0, {"channel_name": "s"}, attributes={"unit": "kmh"}
+        )
+        fact = spark.createDataFrame([(1, ch.get_id(), 0, 1, 1.0)], schema=_FACT_SCHEMA)
+        out = CalculatedChannel.determine_channel_metrics(spark, [ch], fact, attribute_columns=[])
+        assert out.columns == [
+            "container_id",
+            "channel_id",
+            "channel_name",
+            "type",
+            "data_type",
+            "duration",
+            "min",
+            "max",
+            "mean",
+        ]
+
+    def test_identity_wins_on_attribute_collision(self, spark):
+        # A key present in BOTH identity and attribute_columns yields the identity
+        # value, and only one column.
+        ch = CalculatedChannel(
+            "a",
+            TimeSeriesSelector(None) * 1.0,
+            {"channel_name": "s", "unit": "identity_unit"},
+            attributes={"unit": "attr_unit"},
+        )
+        fact = spark.createDataFrame([(1, ch.get_id(), 0, 1, 1.0)], schema=_FACT_SCHEMA)
+        out = CalculatedChannel.determine_channel_metrics(
+            spark, [ch], fact, attribute_columns=["unit"]
+        )
+        assert out.columns.count("unit") == 1
+        assert out.collect()[0]["unit"] == "identity_unit"

--- a/tests/impulse_reporting/unit/config/config_parser_test.py
+++ b/tests/impulse_reporting/unit/config/config_parser_test.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from impulse_reporting.config.config_parser import (
+    CalculatedChannels,
     CastType,
     Comparator,
     ContainerFilters,
@@ -955,3 +956,22 @@ def test_impulse_config_source_rejects_invalid_channel_mapping_table():
     config_json["source"]["channel_mapping_table"] = "invalid_table_name"
     with pytest.raises(ValidationError):
         ImpulseConfig.model_validate(config_json)
+
+
+def test_calculated_channels_default_kpis():
+    """CalculatedChannels defaults to the four built-in KPIs."""
+    config = CalculatedChannels()
+    assert config.emit_channel_metrics is False
+    assert config.kpis == ["duration", "min", "max", "mean"]
+
+
+def test_calculated_channels_kpis_dedupe_preserves_order():
+    """Duplicate KPI names are removed, insertion order preserved."""
+    config = CalculatedChannels(kpis=["mean", "mean", "min"])
+    assert config.kpis == ["mean", "min"]
+
+
+def test_calculated_channels_unknown_kpi_rejected():
+    """An unknown KPI name is rejected at validation with a helpful message."""
+    with pytest.raises(ValidationError, match="Unknown calculated-channel KPI"):
+        CalculatedChannels(kpis=["bogus"])

--- a/tests/impulse_reporting/unit/core/report_utils_test.py
+++ b/tests/impulse_reporting/unit/core/report_utils_test.py
@@ -14,6 +14,7 @@ from impulse_reporting.core.report_utils import (
     build_metadata_dfs,
     dispatch_calculated_channel_metrics,
     dispatch_events,
+    group_dfs_by_table,
     group_selectables_by_type,
     merge_changed_unchanged,
     persist_dimensions_full,
@@ -638,6 +639,41 @@ class TestDispatchCalculatedChannelMetrics:
             kpis=["mean"],
         )
         assert metrics == {}
+
+
+class TestGroupDfsByTable:
+    """Tests for the group-per-output-table shaping helper (returns lists)."""
+
+    def test_empty_returns_empty(self):
+        assert group_dfs_by_table({}, lambda _t: "tbl") == {}
+
+    def test_bare_df_grouped_into_list(self):
+        df = MagicMock(spec=DataFrame)
+        out = group_dfs_by_table({"A": df}, lambda _t: "tbl_a")
+        assert out == {"tbl_a": [df]}
+
+    def test_changed_unchanged_dict_flattened_changed_then_unchanged(self):
+        changed = MagicMock(spec=DataFrame)
+        unchanged = MagicMock(spec=DataFrame)
+        out = group_dfs_by_table(
+            {"A": {"changed": changed, "unchanged": unchanged}}, lambda _t: "tbl_a"
+        )
+        # Order is changed then unchanged (per _fact_dfs_for_table).
+        assert out == {"tbl_a": [changed, unchanged]}
+
+    def test_types_sharing_a_table_are_combined(self):
+        df_a = MagicMock(spec=DataFrame)
+        df_b = MagicMock(spec=DataFrame)
+        out = group_dfs_by_table({"A": df_a, "B": df_b}, lambda _t: "shared")
+        assert out == {"shared": [df_a, df_b]}
+
+    def test_none_and_empty_values_skipped(self):
+        df = MagicMock(spec=DataFrame)
+        out = group_dfs_by_table(
+            {"A": None, "B": {"changed": None, "unchanged": None}, "C": df},
+            lambda t: t,
+        )
+        assert out == {"C": [df]}
 
 
 # ============================================================================

--- a/tests/impulse_reporting/unit/core/report_utils_test.py
+++ b/tests/impulse_reporting/unit/core/report_utils_test.py
@@ -16,6 +16,7 @@ from impulse_reporting.core.report_utils import (
     dispatch_events,
     group_dfs_by_table,
     group_selectables_by_type,
+    persist_channel_metrics,
     merge_changed_unchanged,
     persist_dimensions_full,
     persist_dimensions_incremental,
@@ -1327,3 +1328,68 @@ class TestPersistDimensionsIncremental:
             )
 
         sink.upsert.assert_called_once_with(foo_meta, "uri", ["channel_id"])
+
+
+class TestPersistChannelMetrics:
+    """Tests for the persist_channel_metrics free function (mock-based)."""
+
+    def _mocks(self):
+        combined = MagicMock(spec=DataFrame)
+        combined.transform.return_value = combined  # add_meta_information passthrough
+        transformer = MagicMock()
+        transformer.concat_dataframes.return_value = combined
+        type_enum = MagicMock()
+        type_enum.__getitem__.return_value.get_metrics_table_name.return_value = "metrics"
+        type_enum.get_any_for_metrics_table.return_value = "entity"
+        sink = MagicMock()
+        sink.config.get_output_uri_channel_metrics_table.return_value = "cat.sch.metrics"
+        return combined, transformer, type_enum, sink
+
+    def test_empty_is_noop(self):
+        sink = MagicMock()
+        persist_channel_metrics({}, MagicMock(), sink, MagicMock(), incremental=False)
+        sink.store.assert_not_called()
+        sink.merge_incremental.assert_not_called()
+
+    def test_full_mode_overwrites(self):
+        combined, transformer, type_enum, sink = self._mocks()
+        df = MagicMock(spec=DataFrame)
+
+        persist_channel_metrics(
+            {"CALCULATED_CHANNEL": df}, type_enum, sink, transformer, incremental=False
+        )
+
+        sink.store.assert_called_once_with(combined, "cat.sch.metrics")
+        sink.merge_incremental.assert_not_called()
+
+    def test_incremental_merges_with_keys_and_delete_scope(self):
+        combined, transformer, type_enum, sink = self._mocks()
+        df = MagicMock(spec=DataFrame)
+
+        persist_channel_metrics(
+            {"CALCULATED_CHANNEL": df},
+            type_enum,
+            sink,
+            transformer,
+            incremental=True,
+            updated_container_ids=[1, 2],
+        )
+
+        sink.store.assert_not_called()
+        args, kwargs = sink.merge_incremental.call_args
+        assert args[0] is combined
+        assert args[1] == "cat.sch.metrics"
+        assert args[2] == ["container_id", "channel_id"]
+        # updated containers → one delete-by-source predicate.
+        assert len(kwargs["delete_conditions"]) == 1
+
+    def test_incremental_without_updated_containers_has_no_delete_scope(self):
+        combined, transformer, type_enum, sink = self._mocks()
+        df = MagicMock(spec=DataFrame)
+
+        persist_channel_metrics(
+            {"CALCULATED_CHANNEL": df}, type_enum, sink, transformer, incremental=True
+        )
+
+        _args, kwargs = sink.merge_incremental.call_args
+        assert kwargs["delete_conditions"] == []

--- a/tests/impulse_reporting/unit/core/report_utils_test.py
+++ b/tests/impulse_reporting/unit/core/report_utils_test.py
@@ -12,6 +12,7 @@ from impulse_reporting.core.report import Report
 from impulse_reporting.core.report_utils import (
     build_batches,
     build_metadata_dfs,
+    dispatch_calculated_channel_metrics,
     dispatch_events,
     group_selectables_by_type,
     merge_changed_unchanged,
@@ -555,6 +556,88 @@ class TestDispatchEvents:
         )
 
         assert len(meta_calls) == 0
+
+
+class TestDispatchCalculatedChannelMetrics:
+    """Tests for dispatch_calculated_channel_metrics helper (routing only)."""
+
+    def _make_enum(self, cls):
+        mock_type_enum = MagicMock()
+        mock_type_enum.__getitem__.return_value.value = cls
+        return mock_type_enum
+
+    def test_empty_channels_by_type_returns_empty(self):
+        metrics = dispatch_calculated_channel_metrics(
+            spark=MagicMock(),
+            channels_by_type={},
+            fact_dfs_by_type={},
+            type_enum=MagicMock(),
+            attribute_columns=[],
+            kpis=["mean"],
+        )
+        assert metrics == {}
+
+    def test_routes_fact_df_channels_and_config(self):
+        """Each type's fact df + channel list + config are forwarded verbatim."""
+        mock_result = MagicMock(spec=DataFrame)
+        mock_fact = MagicMock(spec=DataFrame)
+        channel = MagicMock()
+        received = {}
+
+        class FakeCls:
+            @classmethod
+            def determine_channel_metrics(cls, spark, channels, fact_df, **kwargs):
+                received["channels"] = channels
+                received["fact_df"] = fact_df
+                received["kwargs"] = kwargs
+                return mock_result
+
+        metrics = dispatch_calculated_channel_metrics(
+            spark=MagicMock(),
+            channels_by_type={"CALCULATED_CHANNEL": [channel]},
+            fact_dfs_by_type={"CALCULATED_CHANNEL": mock_fact},
+            type_enum=self._make_enum(FakeCls),
+            attribute_columns=["unit"],
+            kpis=["duration", "mean"],
+        )
+
+        assert metrics["CALCULATED_CHANNEL"] is mock_result
+        assert received["channels"] == [channel]
+        assert received["fact_df"] is mock_fact
+        assert received["kwargs"] == {"attribute_columns": ["unit"], "kpis": ["duration", "mean"]}
+
+    def test_type_without_fact_df_is_skipped(self):
+        """A type present in channels but with no fact df (None) yields no entry."""
+        calls = []
+
+        class FakeCls:
+            @classmethod
+            def determine_channel_metrics(cls, spark, channels, fact_df, **kwargs):
+                calls.append(fact_df)
+                return MagicMock(spec=DataFrame)
+
+        metrics = dispatch_calculated_channel_metrics(
+            spark=MagicMock(),
+            channels_by_type={"CALCULATED_CHANNEL": [MagicMock()]},
+            fact_dfs_by_type={"CALCULATED_CHANNEL": None},
+            type_enum=self._make_enum(FakeCls),
+            attribute_columns=[],
+            kpis=["mean"],
+        )
+
+        assert metrics == {}
+        assert calls == []  # determine_channel_metrics never invoked
+
+    def test_empty_channel_list_for_type_is_skipped(self):
+        metrics = dispatch_calculated_channel_metrics(
+            spark=MagicMock(),
+            channels_by_type={"CALCULATED_CHANNEL": []},
+            fact_dfs_by_type={"CALCULATED_CHANNEL": MagicMock(spec=DataFrame)},
+            type_enum=MagicMock(),
+            attribute_columns=[],
+            kpis=["mean"],
+        )
+        assert metrics == {}
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds an opt-in `calculated_channel_metrics` table for calculated channels.
Because `calculated_channel_fact` already matches the silver `channels` shape,
this companion table (silver `channel_metrics` shape) lets the fact + metrics
pair serve as an Impulse silver source in its own right.


## Changes

- New `CalculatedChannels` config section: `emit_channel_metrics` (default
  `false`), `attribute_columns` (default `[]`), and `kpis` (default `duration,
  min, max, mean`). Unknown KPI names are rejected at config validation.
- `CalculatedChannel.determine_channel_metrics` derives the table directly from
  the fact rows, grouped by `(container_id, channel_id)`, with duration-weighted
  semantics matching `SampleSeries`.
- KPIs live in a small registry (`calculated_channel_kpis.KPI_BUILDERS`), so
  adding a new KPI is a one-line change and is then selectable via config.
- Dynamic output schema: fixed `container_id, channel_id, type, data_type`, one
  column per configured KPI, one per identity key (union across the report's
  channels), and one per configured attribute key. An identity key wins over an
  attribute key of the same name.
- Wired into full and incremental persistence (upsert on `container_id,
  channel_id`, pruning stale rows from updated containers). Off by default, so
  existing reports are unchanged.

## Tests

- Unit: KPI derivation (duration-weighted mean, NaN handling, zero-duration
  guard via `try_divide`), dynamic identity/attribute columns, KPI subset and
  ordering, config default/dedupe/unknown-rejection.
- Integration: emit flag on/off, custom KPI selection, incremental idempotency,
  and a round-trip feeding the fact + metrics pair back through `DefaultSolver`.

### Test Plan

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Documentation updated (if applicable)

## Docs

- Updated configuration, gold-layer, data-model, and channel reference pages
  plus the impulse-config, impulse-channels, and impulse-data-model skills.
- Regenerated the pydoc-markdown API reference.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new linter warnings introduced
