### PR TITLE
Feature/metric expression array support

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -37,6 +37,10 @@ jobs:
       labels: linux-ubuntu-latest
     permissions:
       id-token: write
+    # Fork PRs get no OIDC token / secrets from GitHub, so JFrog auth (and therefore
+    # dependency installation) cannot run. Skip CI for them; fork PRs are to be tested
+    # by the reviewer(s) / maintainer(s) before merging.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -63,6 +67,8 @@ jobs:
     needs: [ not-a-fork, lint ]
     permissions:
       id-token: write
+    # See the note on `lint`: fork PRs cannot authenticate to JFrog, so skip CI for them.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -37,10 +37,6 @@ jobs:
       labels: linux-ubuntu-latest
     permissions:
       id-token: write
-    # Fork PRs get no OIDC token / secrets from GitHub, so JFrog auth (and therefore
-    # dependency installation) cannot run. Skip CI for them; fork PRs are to be tested
-    # by the reviewer(s) / maintainer(s) before merging.
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -67,8 +63,6 @@ jobs:
     needs: [ not-a-fork, lint ]
     permissions:
       id-token: write
-    # See the note on `lint`: fork PRs cannot authenticate to JFrog, so skip CI for them.
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/impulse_query_engine/analyze/metadata/metric_expression.py
+++ b/src/impulse_query_engine/analyze/metadata/metric_expression.py
@@ -3,27 +3,8 @@ from __future__ import annotations
 import abc
 import operator
 
-import pandas as pd
 import pyspark.sql.functions as F
 from pyspark.sql import Column
-
-
-def array_contains(arr, value):
-    """``operator``-style callable: does array ``arr`` contain ``value``?
-
-    Analogous to ``operator.eq`` — a plain function usable in the
-    :class:`MetricOp` operation slot — but dual-backend so a ``MetricOp`` built
-    with it evaluates in **both** paths:
-
-    - Spark ``Column`` (``get_selector_expr``) → ``F.array_contains(arr, value)``
-    - pandas ``Series`` of lists (``build_pandas``) → per-row membership.
-
-    ``array_contains`` has no ``operator`` equivalent, so this fills that gap
-    while keeping ``.contains`` structurally identical to the comparison ops.
-    """
-    if isinstance(arr, Column):
-        return F.array_contains(arr, value) # todo double check if this is enforceable
-    return arr.apply(lambda a: value in (a if a is not None else []))
 
 
 class MetricExpression(abc.ABC):
@@ -190,9 +171,10 @@ class MetricExpression(abc.ABC):
     def contains(self, value) -> "MetricOp":
         """
         Membership test for an ``array`` metric: keep rows whose array contains
-        ``value``. Uses the dual-backend :func:`array_contains` operator, so it
-        works in both the Spark (``get_selector_expr``) and pandas
-        (``build_pandas``) paths — symmetric with the comparison ops.
+        ``value``. Uses ``F.array_contains`` as the op, evaluated through the Spark
+        ``get_selector_expr`` path — symmetric with the comparison ops (which use
+        ``operator.eq`` etc.); ``F.array_contains`` fills the array-membership case
+        that has no ``operator`` equivalent.
 
         Used for POI-backed metrics whose values are stored as a plain array,
         e.g. ``q.metric("poi_defect_values").contains("P108B-17")`` alongside a
@@ -207,7 +189,63 @@ class MetricExpression(abc.ABC):
         -------
         MetricOp
         """
-        return MetricOp(array_contains, self, value)
+        return MetricOp(F.array_contains, self, value)
+
+    def contains_any(self, values: list) -> "MetricOp":
+        """
+        Array-membership OR: keep rows whose array shares **any** element with
+        *values* (set intersection non-empty). This is the value-level OR that a
+        single ``.contains`` can't express, e.g.
+        ``q.metric("poi_defect_values").contains_any(["B1024-43", "U0046-13"])``
+        keeps containers that saw *either* code. An empty *values* matches nothing.
+
+        Parameters
+        ----------
+        values : list
+            Elements to test for membership; matches if at least one is present.
+
+        Returns
+        -------
+        MetricOp
+        """
+
+        def array_overlaps(arr: Column, vals: list) -> Column:
+            # Called at get_selector_expr time (Spark active), so the literal
+            # array is built lazily and the tree constructs without a
+            # SparkSession. Empty values overlap nothing → False.
+            if not vals:
+                return F.lit(False)
+            return F.arrays_overlap(arr, F.array(*[F.lit(v) for v in vals]))
+
+        return MetricOp(array_overlaps, self, list(values))
+
+    def contains_all(self, values: list) -> "MetricOp":
+        """
+        Array-membership AND: keep rows whose array contains **every** element of
+        *values*, e.g. ``q.metric("poi_defect_values").contains_all(["B1024-43",
+        "U0046-13"])`` keeps only containers that saw *both* codes. An empty
+        *values* matches everything (vacuously true).
+
+        Parameters
+        ----------
+        values : list
+            Elements that must all be present.
+
+        Returns
+        -------
+        MetricOp
+        """
+
+        def array_contains_all(arr: Column, vals: list) -> Column:
+            # Built lazily at get_selector_expr time. Row survives when the
+            # distinct intersection with arr covers all distinct target values.
+            # Empty values is vacuously True.
+            if not vals:
+                return F.lit(True)
+            target = F.array(*[F.lit(v) for v in vals])
+            return F.size(F.array_intersect(target, arr)) == F.size(F.array_distinct(target))
+
+        return MetricOp(array_contains_all, self, list(values))
 
     @abc.abstractmethod
     def get_selector_expr(self) -> Column:
@@ -218,23 +256,6 @@ class MetricExpression(abc.ABC):
         -------
         pyspark.sql.Column
             Spark SQL column expression for metric selection.
-        """
-        pass
-
-    @abc.abstractmethod
-    def build_pandas(self, df: pd.DataFrame) -> pd.Series:
-        """
-        Build a pandas Series based on the metric expression from the given DataFrame.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            DataFrame containing metric data.
-
-        Returns
-        -------
-        pandas.Series
-            Series representing the metric expression.
         """
         pass
 
@@ -273,22 +294,6 @@ class MetricSelector(MetricExpression):
             Spark SQL column corresponding to the metric key.
         """
         return F.col(self.key)
-
-    def build_pandas(self, df) -> pd.Series:
-        """
-        Return a pandas Series for the selected metric from the DataFrame.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            DataFrame containing metric data.
-
-        Returns
-        -------
-        pandas.Series
-            Series corresponding to the metric key.
-        """
-        return df[self.key]
 
     def __repr__(self):
         """
@@ -358,28 +363,6 @@ class MetricOp(MetricExpression):
             k: a.get_selector_expr() if isinstance(a, MetricExpression) else a
             for k, a in self.kwargs.items()
         }
-        return self.operation(*argsb, **kwargsb)
-
-    def build_pandas(self, df) -> pd.Series:
-        """
-        Build a pandas Series for the metric operation from the given DataFrame.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            DataFrame containing metric data.
-
-        Returns
-        -------
-        pandas.Series
-            Series representing the metric operation.
-        """
-        argsb = [a.build_pandas(df) if isinstance(a, MetricExpression) else a for a in self.args]
-        kwargsb = {
-            k: a.build_pandas(df) if isinstance(a, MetricExpression) else a
-            for k, a in self.kwargs.items()
-        }
-
         return self.operation(*argsb, **kwargsb)
 
     def __repr__(self):

--- a/src/impulse_query_engine/analyze/metadata/metric_expression.py
+++ b/src/impulse_query_engine/analyze/metadata/metric_expression.py
@@ -8,6 +8,24 @@ import pyspark.sql.functions as F
 from pyspark.sql import Column
 
 
+def array_contains(arr, value):
+    """``operator``-style callable: does array ``arr`` contain ``value``?
+
+    Analogous to ``operator.eq`` — a plain function usable in the
+    :class:`MetricOp` operation slot — but dual-backend so a ``MetricOp`` built
+    with it evaluates in **both** paths:
+
+    - Spark ``Column`` (``get_selector_expr``) → ``F.array_contains(arr, value)``
+    - pandas ``Series`` of lists (``build_pandas``) → per-row membership.
+
+    ``array_contains`` has no ``operator`` equivalent, so this fills that gap
+    while keeping ``.contains`` structurally identical to the comparison ops.
+    """
+    if isinstance(arr, Column):
+        return F.array_contains(arr, value) # todo double check if this is enforceable
+    return arr.apply(lambda a: value in (a if a is not None else []))
+
+
 class MetricExpression(abc.ABC):
     def __eq__(self, other):
         """
@@ -168,6 +186,28 @@ class MetricExpression(abc.ABC):
             Metric operation representing logical AND.
         """
         return MetricOp(operator.and_, other, self)
+
+    def contains(self, value) -> "MetricOp":
+        """
+        Membership test for an ``array`` metric: keep rows whose array contains
+        ``value``. Uses the dual-backend :func:`array_contains` operator, so it
+        works in both the Spark (``get_selector_expr``) and pandas
+        (``build_pandas``) paths — symmetric with the comparison ops.
+
+        Used for POI-backed metrics whose values are stored as a plain array,
+        e.g. ``q.metric("poi_defect_values").contains("P108B-17")`` alongside a
+        separate scalar ``q.metric("poi_defect_count") >= 3``.
+
+        Parameters
+        ----------
+        value
+            The element to test for membership.
+
+        Returns
+        -------
+        MetricOp
+        """
+        return MetricOp(array_contains, self, value)
 
     @abc.abstractmethod
     def get_selector_expr(self) -> Column:

--- a/src/impulse_query_engine/analyze/metadata/metric_expression.py
+++ b/src/impulse_query_engine/analyze/metadata/metric_expression.py
@@ -176,9 +176,9 @@ class MetricExpression(abc.ABC):
         ``operator.eq`` etc.); ``F.array_contains`` fills the array-membership case
         that has no ``operator`` equivalent.
 
-        Used for POI-backed metrics whose values are stored as a plain array,
-        e.g. ``q.metric("poi_defect_values").contains("P108B-17")`` alongside a
-        separate scalar ``q.metric("poi_defect_count") >= 3``.
+        Used for metrics whose values are stored as a plain array,
+        e.g. ``q.metric("values").contains("ABCD-17")``.
+        Can be used alongside the existing metric filters.
 
         Parameters
         ----------

--- a/src/impulse_query_engine/analyze/query/solvers/blob_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/blob_solver.py
@@ -29,12 +29,15 @@ class TimeSeriesCache(SeriesCache):
 
     def resolve(self, selection):
         """
-        Resolve selected tags/metrics to a list of candidates.
+        Resolve a channel (time-series) selector to its candidate rows.
 
         Parameters
         ----------
-        selection : Any
-            The selection object specifying tags or metrics.
+        selection : TimeSeriesSelector
+            The channel selector whose tag expression (``selection._expr``)
+            identifies the matching channel(s). Metric filters do not flow
+            through here — they are evaluated in Spark via ``get_selector_expr``
+            during ``filter_container_metrics``.
 
         Returns
         -------

--- a/src/impulse_query_engine/analyze/query/solvers/blob_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/blob_solver.py
@@ -35,9 +35,7 @@ class TimeSeriesCache(SeriesCache):
         ----------
         selection : TimeSeriesSelector
             The channel selector whose tag expression (``selection._expr``)
-            identifies the matching channel(s). Metric filters do not flow
-            through here — they are evaluated in Spark via ``get_selector_expr``
-            during ``filter_container_metrics``.
+            identifies the matching channel(s).
 
         Returns
         -------

--- a/src/impulse_query_engine/analyze/query/solvers/default_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/default_solver.py
@@ -78,12 +78,15 @@ class TimeSeriesCache(SeriesCache):
 
     def resolve(self, selection):
         """
-        Resolve selected tags/metrics to a list of candidates.
+        Resolve a channel (time-series) selector to its candidate rows.
 
         Parameters
         ----------
-        selection : Any
-            The selection object specifying tags or metrics.
+        selection : TimeSeriesSelector
+            The channel selector whose tag expression (``selection._expr``)
+            identifies the matching channel(s). Metric filters do not flow
+            through here — they are evaluated in Spark via ``get_selector_expr``
+            during ``filter_container_metrics``.
 
         Returns
         -------

--- a/src/impulse_query_engine/analyze/query/solvers/default_solver.py
+++ b/src/impulse_query_engine/analyze/query/solvers/default_solver.py
@@ -84,10 +84,7 @@ class TimeSeriesCache(SeriesCache):
         ----------
         selection : TimeSeriesSelector
             The channel selector whose tag expression (``selection._expr``)
-            identifies the matching channel(s). Metric filters do not flow
-            through here — they are evaluated in Spark via ``get_selector_expr``
-            during ``filter_container_metrics``.
-
+            identifies the matching channel(s).
         Returns
         -------
         pd.DataFrame

--- a/src/impulse_query_engine/analyze/query/solvers/empty_cache.py
+++ b/src/impulse_query_engine/analyze/query/solvers/empty_cache.py
@@ -15,8 +15,8 @@ class EmptyTimeSeriesCache(SeriesCache):
 
         Parameters
         ----------
-        selection : Any
-            The selection object specifying tags or metrics.
+        selection : TimeSeriesSelector
+            The channel selector; ignored by this cache.
 
         Returns
         -------

--- a/src/impulse_query_engine/analyze/query/solvers/series_cache.py
+++ b/src/impulse_query_engine/analyze/query/solvers/series_cache.py
@@ -9,12 +9,15 @@ class SeriesCache(ABC):
     @abstractmethod
     def resolve(self, selection) -> pd.DataFrame:
         """
-        Resolve selected tags/metrics to a list of candidates.
+        Resolve a channel (time-series) selector to its candidate rows.
 
         Parameters
         ----------
-        selection : Any
-            The selection object specifying tags or metrics.
+        selection : TimeSeriesSelector
+            The channel selector whose tag expression (``selection._expr``)
+            identifies the matching channel(s). Metric filters do not flow
+            through here — they are evaluated in Spark via ``get_selector_expr``
+            during ``filter_container_metrics``.
 
         Returns
         -------

--- a/tests/impulse_query_engine/unit/analyze/query/solvers/metric_array_filter_test.py
+++ b/tests/impulse_query_engine/unit/analyze/query/solvers/metric_array_filter_test.py
@@ -1,0 +1,134 @@
+# pylint: disable=missing-function-docstring, redefined-outer-name
+"""Spark-evaluating tests for array-membership MetricExpression operators.
+
+``.contains`` / ``.contains_any`` / ``.contains_all`` build a boolean predicate
+that runs in ``filter_container_metrics`` (Spark ``.where``). These tests assert
+the *filtering semantics* — which containers survive — against an in-memory
+``container_metrics`` table carrying an ``array<string>`` column, which no CSV
+fixture can express. The pure builder-structure tests live in
+``unit/model/expressions/metric_expression_test.py``.
+
+Set fixture (``poi_defect_values`` per container):
+    c1 → [A, B]   c2 → [A]   c3 → [C]   c4 → [] (empty)
+"""
+
+from unittest.mock import create_autospec
+
+import pytest
+import pyspark.sql.types as T
+from databricks.sdk import WorkspaceClient
+from pyspark.sql import SparkSession
+
+from impulse_query_engine.analyze.metadata.metric_expression import MetricSelector
+from impulse_query_engine.analyze.query.solvers.default_solver import DefaultSolver
+from impulse_query_engine.analyze.query.solvers.solver_config import SolverConfig
+from impulse_query_engine.measurement_db import MeasurementDB, MeasurementDBConfig
+from tests.conftest import spark
+
+
+@pytest.fixture
+def array_metric_db(spark: SparkSession) -> MeasurementDB:
+    """Wide-only in-memory DB whose container_metrics has an array<string> column."""
+    schema = T.StructType(
+        [
+            T.StructField("container_id", T.LongType()),
+            T.StructField("poi_defect_values", T.ArrayType(T.StringType())),
+        ]
+    )
+    container_metrics = spark.createDataFrame(
+        [
+            (1, ["A", "B"]),
+            (2, ["A"]),
+            (3, ["C"]),
+            (4, []),
+        ],
+        schema=schema,
+    )
+    cfg = MeasurementDBConfig.for_debug({"container_metrics": container_metrics})
+    return MeasurementDB(cfg, ws=create_autospec(WorkspaceClient))
+
+
+def _survivors(db: MeasurementDB, spark: SparkSession, predicate) -> set:
+    """Apply *predicate* through filter_container_metrics and return surviving ids."""
+    solver = DefaultSolver(spark, config=SolverConfig())  # wide-only, no project_id
+    query = db.query
+    query.where(predicate)
+    tags_df = solver.filter_container_tags(spark, query)  # empty in wide-only mode
+    result = solver.filter_container_metrics(spark, query, tags_df)
+    return {row.container_id for row in result.collect()}
+
+
+class TestContains:
+    def test_contains_single_value(self, spark: SparkSession, array_metric_db: MeasurementDB):
+        """`.contains("A")` keeps containers whose set includes A → c1, c2."""
+        got = _survivors(array_metric_db, spark, MetricSelector("poi_defect_values").contains("A"))
+        assert got == {1, 2}
+
+    def test_contains_absent_value_keeps_none(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        got = _survivors(array_metric_db, spark, MetricSelector("poi_defect_values").contains("Z"))
+        assert got == set()
+
+
+class TestContainsAny:
+    def test_contains_any_is_union(self, spark: SparkSession, array_metric_db: MeasurementDB):
+        """`.contains_any([A, C])` keeps any container with A or C → c1, c2, c3."""
+        pred = MetricSelector("poi_defect_values").contains_any(["A", "C"])
+        assert _survivors(array_metric_db, spark, pred) == {1, 2, 3}
+
+    def test_contains_any_single_matches_like_contains(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        pred = MetricSelector("poi_defect_values").contains_any(["B"])
+        assert _survivors(array_metric_db, spark, pred) == {1}
+
+    def test_contains_any_none_present(self, spark: SparkSession, array_metric_db: MeasurementDB):
+        pred = MetricSelector("poi_defect_values").contains_any(["Y", "Z"])
+        assert _survivors(array_metric_db, spark, pred) == set()
+
+    def test_contains_any_empty_list_matches_nothing(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        """An empty candidate set overlaps nothing → no survivors (incl. the empty-set c4)."""
+        pred = MetricSelector("poi_defect_values").contains_any([])
+        assert _survivors(array_metric_db, spark, pred) == set()
+
+
+class TestContainsAll:
+    def test_contains_all_requires_every_value(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        """`.contains_all([A, B])` keeps only the set containing both → c1."""
+        pred = MetricSelector("poi_defect_values").contains_all(["A", "B"])
+        assert _survivors(array_metric_db, spark, pred) == {1}
+
+    def test_contains_all_single_value(self, spark: SparkSession, array_metric_db: MeasurementDB):
+        pred = MetricSelector("poi_defect_values").contains_all(["A"])
+        assert _survivors(array_metric_db, spark, pred) == {1, 2}
+
+    def test_contains_all_partial_match_excluded(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        """c2 has A but not C, so `.contains_all([A, C])` excludes it → none."""
+        pred = MetricSelector("poi_defect_values").contains_all(["A", "C"])
+        assert _survivors(array_metric_db, spark, pred) == set()
+
+    def test_contains_all_empty_list_matches_all(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        """Vacuously true: an empty required set is satisfied by every container."""
+        pred = MetricSelector("poi_defect_values").contains_all([])
+        assert _survivors(array_metric_db, spark, pred) == {1, 2, 3, 4}
+
+
+class TestComposition:
+    def test_contains_any_ands_with_scalar_metric(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        """Array op composes with a scalar comparison via `&`."""
+        pred = (MetricSelector("poi_defect_values").contains_any(["A", "C"])) & (
+            MetricSelector("container_id") <= 2
+        )
+        # A-or-C → {1,2,3}; container_id <= 2 → {1,2}; AND → {1,2}
+        assert _survivors(array_metric_db, spark, pred) == {1, 2}

--- a/tests/impulse_query_engine/unit/analyze/query/solvers/metric_array_filter_test.py
+++ b/tests/impulse_query_engine/unit/analyze/query/solvers/metric_array_filter_test.py
@@ -132,3 +132,104 @@ class TestComposition:
         )
         # A-or-C → {1,2,3}; container_id <= 2 → {1,2}; AND → {1,2}
         assert _survivors(array_metric_db, spark, pred) == {1, 2}
+
+
+@pytest.fixture
+def duplicate_array_metric_db(spark: SparkSession) -> MeasurementDB:
+    """DB whose array column carries duplicate elements within a container.
+
+    c1 → [A, A, B]   c2 → [A]   (c1's repeated A must not change membership logic)
+    """
+    schema = T.StructType(
+        [
+            T.StructField("container_id", T.LongType()),
+            T.StructField("poi_defect_values", T.ArrayType(T.StringType())),
+        ]
+    )
+    container_metrics = spark.createDataFrame(
+        [(1, ["A", "A", "B"]), (2, ["A"])],
+        schema=schema,
+    )
+    cfg = MeasurementDBConfig.for_debug({"container_metrics": container_metrics})
+    return MeasurementDB(cfg, ws=create_autospec(WorkspaceClient))
+
+
+class TestDuplicateElements:
+    """Membership is set-based: repeated elements in the stored array or in the
+    candidate list must not change which containers survive."""
+
+    def test_contains_all_handles_duplicates_in_stored_array(
+        self, spark: SparkSession, duplicate_array_metric_db: MeasurementDB
+    ):
+        """c1=[A,A,B] contains both A and B despite the repeated A → kept."""
+        pred = MetricSelector("poi_defect_values").contains_all(["A", "B"])
+        assert _survivors(duplicate_array_metric_db, spark, pred) == {1}
+
+    def test_contains_all_handles_duplicate_values_in_query(
+        self, spark: SparkSession, duplicate_array_metric_db: MeasurementDB
+    ):
+        """A duplicated candidate (``["A", "A"]``) is de-duplicated, so it behaves
+        like ``["A"]`` → every container holding A survives (c1, c2)."""
+        pred = MetricSelector("poi_defect_values").contains_all(["A", "A"])
+        assert _survivors(duplicate_array_metric_db, spark, pred) == {1, 2}
+
+
+@pytest.fixture
+def numeric_array_metric_db(spark: SparkSession) -> MeasurementDB:
+    """DB whose array column is ``array<long>`` rather than ``array<string>``."""
+    schema = T.StructType(
+        [
+            T.StructField("container_id", T.LongType()),
+            T.StructField("codes", T.ArrayType(T.LongType())),
+        ]
+    )
+    container_metrics = spark.createDataFrame(
+        [(1, [10, 20]), (2, [20]), (3, [30])],
+        schema=schema,
+    )
+    cfg = MeasurementDBConfig.for_debug({"container_metrics": container_metrics})
+    return MeasurementDB(cfg, ws=create_autospec(WorkspaceClient))
+
+
+class TestNonStringArrays:
+    """The operators are element-type agnostic; exercise a numeric array column."""
+
+    def test_contains_numeric(self, spark: SparkSession, numeric_array_metric_db: MeasurementDB):
+        pred = MetricSelector("codes").contains(20)
+        assert _survivors(numeric_array_metric_db, spark, pred) == {1, 2}
+
+    def test_contains_any_numeric(
+        self, spark: SparkSession, numeric_array_metric_db: MeasurementDB
+    ):
+        pred = MetricSelector("codes").contains_any([10, 30])
+        assert _survivors(numeric_array_metric_db, spark, pred) == {1, 3}
+
+    def test_contains_all_numeric(
+        self, spark: SparkSession, numeric_array_metric_db: MeasurementDB
+    ):
+        pred = MetricSelector("codes").contains_all([10, 20])
+        assert _survivors(numeric_array_metric_db, spark, pred) == {1}
+
+
+class TestValueListSnapshot:
+    """``contains_any``/``contains_all`` snapshot their candidate list at build
+    time (via ``list(values)``), so mutating the caller's list afterwards must not
+    change the predicate."""
+
+    def test_contains_any_snapshots_values(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        vals = ["A"]
+        pred = MetricSelector("poi_defect_values").contains_any(vals)
+        vals.append("C")  # must NOT leak into the already-built predicate
+        # Still A-only → {1, 2}; would be {1, 2, 3} if the append leaked in.
+        assert _survivors(array_metric_db, spark, pred) == {1, 2}
+
+    def test_contains_all_snapshots_values(
+        self, spark: SparkSession, array_metric_db: MeasurementDB
+    ):
+        vals = ["A"]
+        pred = MetricSelector("poi_defect_values").contains_all(vals)
+        vals.append("B")  # must NOT tighten the predicate to require B too
+        # Still A-only → {1, 2}; would be {1} if the append leaked in.
+        assert _survivors(array_metric_db, spark, pred) == {1, 2}

--- a/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
+++ b/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
@@ -7,6 +7,36 @@ from impulse_query_engine.analyze.metadata.metric_expression import MetricOp, Me
 # --- Comparison operator tests ---
 
 
+# --- Array-membership operator tests (structure only; evaluation in md/expressions) ---
+
+
+def test_contains_builds_metric_op():
+    expr = MetricSelector("poi_defect_values").contains("B1024-43")
+    assert isinstance(expr, MetricOp)
+    assert expr.required_metrics() == {"poi_defect_values"}
+
+
+def test_contains_any_builds_metric_op():
+    expr = MetricSelector("poi_defect_values").contains_any(["B1024-43", "U0046-13"])
+    assert isinstance(expr, MetricOp)
+    assert expr.required_metrics() == {"poi_defect_values"}
+
+
+def test_contains_all_builds_metric_op():
+    expr = MetricSelector("poi_defect_values").contains_all(["B1024-43", "U0046-13"])
+    assert isinstance(expr, MetricOp)
+    assert expr.required_metrics() == {"poi_defect_values"}
+
+
+def test_array_ops_compose_with_scalar_metrics():
+    """An array op ANDs/ORs with ordinary comparisons, unioning required metrics."""
+    expr = (MetricSelector("poi_defect_values").contains_any(["A", "B"])) & (
+        MetricSelector("duration_ms") > 30
+    )
+    assert isinstance(expr, MetricOp)
+    assert expr.required_metrics() == {"poi_defect_values", "duration_ms"}
+
+
 def test_eq():
     expr = MetricSelector("start_dt") == "2023-08-16T00:00:000Z"
     assert isinstance(expr, MetricOp)

--- a/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
+++ b/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
@@ -4,6 +4,43 @@
 
 from impulse_query_engine.analyze.metadata.metric_expression import MetricOp, MetricSelector
 
+# --- Evaluation-path invariants ---
+
+
+def test_metric_expression_is_spark_evaluated_not_pandas():
+    """Metric filtering evaluates in Spark via ``get_selector_expr``, never the
+    pandas ``resolve()`` / ``build_pandas`` path.
+
+    ``build_pandas`` was removed from ``MetricExpression`` in the array-support
+    refactor. The only surviving ``build_pandas`` callers
+    (``TimeSeriesCache.resolve``) receive a ``TimeSeriesSelector`` whose ``_expr``
+    is always a ``TagExpression`` — a metric expression can never reach them.
+    This locks the separation in: if a metric ever gained a ``build_pandas`` again
+    (or lost ``get_selector_expr``), that would signal the two paths are blurring.
+    """
+    sel = MetricSelector("poi_defect_values")
+    op = sel.contains("A")
+    for expr in (sel, op):
+        assert hasattr(expr, "get_selector_expr")  # the real metric eval path
+        assert not hasattr(expr, "build_pandas")  # the deleted, unreachable one
+
+
+def test_metric_expression_is_not_serializable():
+    """Metric expressions have no ``as_dict``/``from_dict``.
+
+    This is *why* a ``MetricSelector`` can never be smuggled into a
+    ``TimeSeriesSelector._expr`` via ``from_dict`` deserialization (and thus never
+    reach the pandas ``resolve`` path): there is no serialized form to resolve back
+    to a metric class. Tag expressions, which legitimately populate ``_expr``, are
+    serializable; metric expressions are deliberately not.
+    """
+    sel = MetricSelector("poi_defect_values")
+    op = sel.contains_any(["A", "B"])
+    for expr in (sel, op):
+        assert not hasattr(expr, "as_dict")
+        assert not hasattr(expr, "from_dict")
+
+
 # --- Comparison operator tests ---
 
 

--- a/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
+++ b/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
@@ -4,27 +4,6 @@
 
 from impulse_query_engine.analyze.metadata.metric_expression import MetricOp, MetricSelector
 
-# --- Evaluation-path invariants ---
-
-
-def test_metric_expression_is_spark_evaluated_not_pandas():
-    """Metric filtering evaluates in Spark via ``get_selector_expr``, never the
-    pandas ``resolve()`` / ``build_pandas`` path.
-
-    ``build_pandas`` was removed from ``MetricExpression`` in the array-support
-    refactor. The only surviving ``build_pandas`` callers
-    (``TimeSeriesCache.resolve``) receive a ``TimeSeriesSelector`` whose ``_expr``
-    is always a ``TagExpression`` — a metric expression can never reach them.
-    This locks the separation in: if a metric ever gained a ``build_pandas`` again
-    (or lost ``get_selector_expr``), that would signal the two paths are blurring.
-    """
-    sel = MetricSelector("poi_defect_values")
-    op = sel.contains("A")
-    for expr in (sel, op):
-        assert hasattr(expr, "get_selector_expr")  # the real metric eval path
-        assert not hasattr(expr, "build_pandas")  # the deleted, unreachable one
-
-
 def test_metric_expression_is_not_serializable():
     """Metric expressions have no ``as_dict``/``from_dict``.
 
@@ -42,8 +21,6 @@ def test_metric_expression_is_not_serializable():
 
 
 # --- Comparison operator tests ---
-
-
 # --- Array-membership operator tests (structure only; evaluation in md/expressions) ---
 
 

--- a/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
+++ b/tests/impulse_query_engine/unit/model/expressions/metric_expression_test.py
@@ -4,6 +4,7 @@
 
 from impulse_query_engine.analyze.metadata.metric_expression import MetricOp, MetricSelector
 
+
 def test_metric_expression_is_not_serializable():
     """Metric expressions have no ``as_dict``/``from_dict``.
 


### PR DESCRIPTION
## Summary   

Adds array-membership filter operators to `MetricExpression` for querying
POI-backed metrics whose values are stored as arrays, and removes the now-unused   
pandas evaluation path from metric expressions. 

## Changes   

- **Array operators** on `MetricExpression` (`metric_expression.py`):    
- `.contains(value)` — array membership (`F.array_contains`) 
- `.contains_any([...])` — non-empty intersection (OR); empty list matches nothing    
- `.contains_all([...])` — superset (AND); empty list matches everything    

e.g. `q.metric("poi_defect_values").contains_any(["B1024-43", "U0046-13"])`.
They compose with the existing scalar comparisons and `&`/`|`, and evaluate in   
Spark via `get_selector_expr`. 
- **Removed `build_pandas`** from `MetricExpression`/`MetricSelector`/`MetricOp`.  
It was dead code for metrics — metric filters run through Spark, and the only    
`build_pandas` callers (`TimeSeriesCache.resolve`) only ever receive a 
`TagExpression`. `TagExpression.build_pandas` is untouched.  
- **Docstring fix**: `SeriesCache.resolve` (and the blob/default/empty caches)
said it resolves "tags/metrics"; it only ever resolves a `TimeSeriesSelector`'s  
tag expression. Corrected to say so.


## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Documentation updated (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No new linter warnings introduced
