### PR TITLE
Pin silver input tables to fixed Delta versions per report run

### DIFF
--- a/docs/impulse/docs/references/query_engine/index.md
+++ b/docs/impulse/docs/references/query_engine/index.md
@@ -26,3 +26,25 @@ silver-layer data. It has two parts:
 - **As the foundation of the [Report](../report/index.md) component.** The reporting layer embeds TSAL
   expressions in events and aggregations, and the `Report` orchestrator batch-solves them through the
   query engine and persists the results to the gold layer.
+
+## Snapshot consistency
+
+A single solve fans out into many lazy reads across the silver tables. By default each read sees the
+_latest_ Delta version at the moment it materializes, so a table that changes mid-analysis can be
+observed inconsistently across those reads.
+
+To freeze a consistent snapshot, pin the silver tables to their current Delta versions before
+querying — every subsequent read then uses `versionAsOf` that pinned version:
+
+```python
+db.pin_versions(spark)   # resolve each table's current version once
+result = db.query.select(...).solve(spark, solver=DefaultSolver(spark))
+```
+
+:::note Opt-in for direct use, automatic in reporting
+For direct query-engine use, pinning is **opt-in** — call `pin_versions` yourself when you want it.
+The pin is stored on the config and **persists until cleared**, so a long-lived `MeasurementDB` keeps
+reading the pinned snapshot until you re-pin (call it again) or unpin (`db.config.pinned_versions = {}`).
+The [Report](../report/index.md) component pins automatically at the start of every run, so snapshot
+consistency there needs no action.
+:::

--- a/src/impulse_query_engine/measurement_db.py
+++ b/src/impulse_query_engine/measurement_db.py
@@ -1,3 +1,5 @@
+import warnings
+
 from databricks.sdk import WorkspaceClient
 from pyspark.sql import DataFrame
 
@@ -31,6 +33,10 @@ class MeasurementDBConfig:
         self.unit_conversion_table = unit_conversion_table
         self.table_locations = table_locations
         self.debug_tables = None
+        # URI -> pinned Delta version, populated once per run by
+        # ``MeasurementDB.pin_versions``. Empty means "read latest" (unchanged
+        # behavior). Never populated in debug mode.
+        self.pinned_versions: dict[str, int] = {}
 
     @staticmethod
     def for_unity_catalog(
@@ -86,14 +92,70 @@ class MeasurementDB:
     def query(self):
         return QueryBuilder(db=self)
 
+    def _configured_table_uris(self) -> list[str]:
+        """Return the URIs of every configured (non-``None``) silver table."""
+        return [
+            uri
+            for uri in (
+                self.config.container_tags_table,
+                self.config.container_metrics_table,
+                self.config.channel_tags_table,
+                self.config.channel_metrics_table,
+                self.config.channels_uri,
+                self.config.poi_channels_uri,
+                self.config.channel_mapping_table,
+                self.config.unit_conversion_table,
+            )
+            if uri is not None
+        ]
+
+    @staticmethod
+    def _current_delta_version(spark, table_locations: str, uri: str) -> int:
+        """Resolve the latest committed Delta version of ``uri``.
+
+        Handles UC (``catalog.schema.table``, resolved by ``forName`` with the
+        full name) and path modes. Read-only: if the reference cannot be
+        resolved (view, non-Delta, unknown table), the error propagates to
+        :meth:`pin_versions`, which skips pinning that table so it keeps reading
+        the latest version — never a wrong one.
+        """
+        from delta.tables import DeltaTable
+
+        if table_locations == "unity_catalog":
+            dt = DeltaTable.forName(spark, uri)
+        else:  # path mode
+            dt = DeltaTable.forPath(spark, uri)
+        return int(dt.history(1).select("version").first()[0])
+
+    def pin_versions(self, spark) -> None:
+        """Pin every configured silver table to its current Delta version.
+
+        Resolves each table's latest version once so that all lazily-evaluated
+        reads in a run observe the same snapshot regardless of when they
+        materialize (issue #87). Debug mode is exempt. Tables that cannot be
+        time-traveled (views, non-Delta, unresolvable) are skipped with a
+        warning and continue to read the latest version.
+        """
+        if self.config.table_locations == "debug":
+            return
+        pinned: dict[str, int] = {}
+        for uri in self._configured_table_uris():
+            try:
+                pinned[uri] = self._current_delta_version(spark, self.config.table_locations, uri)
+            except Exception as exc:  # noqa: BLE001 - graceful degradation per table
+                warnings.warn(f"Could not pin Delta version for '{uri}': {exc}", stacklevel=2)
+        self.config.pinned_versions = pinned
+
     def _read_table(self, spark, table_name):
-        # if not DeltaTable.isDeltaTable(spark, table_name):
-        #    raise Exception(f"Table not found: `{table_name}`")
-        if self.config.table_locations == "unity_catalog":
-            return spark.read.table(table_name)
-        elif self.config.table_locations == "debug":
+        if self.config.table_locations == "debug":
             return self.config.debug_tables[table_name]
-        return spark.read.format("delta").load(table_name)
+        reader = spark.read
+        version = self.config.pinned_versions.get(table_name)
+        if version is not None:
+            reader = reader.option("versionAsOf", version)
+        if self.config.table_locations == "unity_catalog":
+            return reader.table(table_name)
+        return reader.format("delta").load(table_name)
 
     def container_tags(self, spark) -> DataFrame:
         return self._read_table(spark, self.config.container_tags_table)

--- a/src/impulse_query_engine/measurement_db.py
+++ b/src/impulse_query_engine/measurement_db.py
@@ -135,6 +135,19 @@ class MeasurementDB:
         materialize (issue #87). Debug mode is exempt. Tables that cannot be
         time-traveled (views, non-Delta, unresolvable) are skipped with a
         warning and continue to read the latest version.
+
+        **Opt-in for direct query-engine use.** This is *not* called
+        automatically when you query a ``MeasurementDB`` directly — reads
+        return the latest version unless you call this first. Call it when you
+        want a fan-out of lazy reads to see a stable snapshot even if the silver
+        tables change mid-analysis. The reporting layer (``Report``) calls it
+        for you at the start of every run, so snapshot consistency there is
+        automatic.
+
+        The pin is stored on the config and **persists until cleared** — a
+        long-lived ``MeasurementDB`` will keep reading the pinned snapshot (and
+        never see newer data) until you re-pin (call again) or unpin
+        (``db.config.pinned_versions = {}``).
         """
         if self.config.table_locations == "debug":
             return

--- a/src/impulse_query_engine/measurement_db.py
+++ b/src/impulse_query_engine/measurement_db.py
@@ -82,6 +82,23 @@ class MeasurementDBConfig:
         cfg.debug_tables = debug_tables
         return cfg
 
+    def configured_table_uris(self) -> list[str]:
+        """Return the URIs of every configured (non-``None``) silver table."""
+        return [
+            uri
+            for uri in (
+                self.container_tags_table,
+                self.container_metrics_table,
+                self.channel_tags_table,
+                self.channel_metrics_table,
+                self.channels_uri,
+                self.poi_channels_uri,
+                self.channel_mapping_table,
+                self.unit_conversion_table,
+            )
+            if uri is not None
+        ]
+
 
 class MeasurementDB:
     def __init__(self, config: MeasurementDBConfig, ws: WorkspaceClient):
@@ -91,23 +108,6 @@ class MeasurementDB:
     @property
     def query(self):
         return QueryBuilder(db=self)
-
-    def _configured_table_uris(self) -> list[str]:
-        """Return the URIs of every configured (non-``None``) silver table."""
-        return [
-            uri
-            for uri in (
-                self.config.container_tags_table,
-                self.config.container_metrics_table,
-                self.config.channel_tags_table,
-                self.config.channel_metrics_table,
-                self.config.channels_uri,
-                self.config.poi_channels_uri,
-                self.config.channel_mapping_table,
-                self.config.unit_conversion_table,
-            )
-            if uri is not None
-        ]
 
     @staticmethod
     def _current_delta_version(spark, table_locations: str, uri: str) -> int:
@@ -152,7 +152,7 @@ class MeasurementDB:
         if self.config.table_locations == "debug":
             return
         pinned: dict[str, int] = {}
-        for uri in self._configured_table_uris():
+        for uri in self.config.configured_table_uris():
             try:
                 pinned[uri] = self._current_delta_version(spark, self.config.table_locations, uri)
             except Exception as exc:  # noqa: BLE001 - graceful degradation per table

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -937,6 +937,11 @@ class Report:
         # Validate that every aggregation references a registered event
         self._validate_aggregation_events()
 
+        # Pin one consistent Delta snapshot of every configured silver input for
+        # the whole run so mid-run table changes cannot leak across lazy stages
+        # (issue #87).
+        self.db.pin_versions(self.spark)
+
         # TODO: port unit-consistency sanity check from MDA Framework
         # (`mda_reporting/util/unit_sanity_check.py`). When a
         # `unit_conversion_table` is configured, walk all aggregation /

--- a/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
+++ b/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
@@ -50,6 +50,25 @@ def test_pin_versions_freezes_snapshot(spark, pin_schema):  # noqa: F811
     assert db.container_metrics(spark).count() == 10
 
 
+def test_pin_versions_freezes_snapshot_path_mode(spark, tmp_path):  # noqa: F811
+    # Path mode (``external_locations``): reads and version resolution go through
+    # the filesystem path rather than a catalog name.
+    path = str(tmp_path / "container_metrics")
+    spark.range(3).toDF("container_id").write.format("delta").mode("overwrite").save(path)
+
+    cfg = MeasurementDBConfig(container_metrics_table=path, table_locations="external_locations")
+    db = _db(cfg)
+    db.pin_versions(spark)
+    assert cfg.pinned_versions == {path: 0}
+
+    # Mutate after pinning; the pinned read must still see the original snapshot.
+    spark.range(3, 10).toDF("container_id").write.format("delta").mode("append").save(path)
+    assert db.container_metrics(spark).count() == 3
+
+    cfg.pinned_versions = {}
+    assert db.container_metrics(spark).count() == 10
+
+
 def test_pin_versions_skips_debug_mode(spark):  # noqa: F811
     cfg = MeasurementDBConfig.for_debug({"container_metrics": spark.range(2).toDF("container_id")})
     db = _db(cfg)

--- a/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
+++ b/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
@@ -1,0 +1,71 @@
+# pylint: disable=missing-function-docstring
+"""Tests for per-run Delta version pinning on ``MeasurementDB`` (issue #87).
+
+``pin_versions`` resolves each configured silver table's current Delta version
+once at run start; ``_read_table`` then reads with ``versionAsOf`` so every
+lazy op in the run observes the same snapshot even if the table changes
+mid-run. Debug mode is exempt; non-Delta / unresolvable tables are skipped
+with a warning and continue to read the latest version.
+"""
+
+from unittest.mock import create_autospec
+
+import pytest
+from databricks.sdk import WorkspaceClient
+
+from impulse_query_engine.measurement_db import MeasurementDB, MeasurementDBConfig
+from tests.conftest import spark  # noqa: F401  (pytest fixture)
+
+_PIN_SCHEMA = "spark_catalog.silver_pin_test"
+
+
+def _db(cfg: MeasurementDBConfig) -> MeasurementDB:
+    return MeasurementDB(cfg, ws=create_autospec(WorkspaceClient))
+
+
+@pytest.fixture
+def pin_schema(spark):  # noqa: F811
+    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {_PIN_SCHEMA}")
+    yield _PIN_SCHEMA
+    spark.sql(f"DROP SCHEMA IF EXISTS {_PIN_SCHEMA} CASCADE")
+
+
+def test_pin_versions_freezes_snapshot(spark, pin_schema):  # noqa: F811
+    table = f"{pin_schema}.container_metrics"
+    spark.range(3).toDF("container_id").write.format("delta").mode("overwrite").saveAsTable(table)
+
+    cfg = MeasurementDBConfig(container_metrics_table=table, table_locations="unity_catalog")
+    db = _db(cfg)
+    db.pin_versions(spark)
+    assert cfg.pinned_versions == {table: 0}
+
+    # Mutate the table AFTER pinning but BEFORE the (lazy) read materializes.
+    spark.range(3, 10).toDF("container_id").write.format("delta").mode("append").saveAsTable(table)
+
+    # The read still reflects the pinned snapshot, not the 10-row mutated table.
+    assert db.container_metrics(spark).count() == 3
+
+    # Without a pin, the same read sees the latest snapshot.
+    cfg.pinned_versions = {}
+    assert db.container_metrics(spark).count() == 10
+
+
+def test_pin_versions_skips_debug_mode(spark):  # noqa: F811
+    cfg = MeasurementDBConfig.for_debug({"container_metrics": spark.range(2).toDF("container_id")})
+    db = _db(cfg)
+    db.pin_versions(spark)
+    # Debug mode is exempt: nothing pinned, and reads return the in-memory df.
+    assert cfg.pinned_versions == {}
+    assert db.container_metrics(spark).count() == 2
+
+
+def test_pin_versions_skips_non_delta_and_warns(spark):  # noqa: F811
+    cfg = MeasurementDBConfig(
+        container_metrics_table="spark_catalog.silver_pin_test.does_not_exist",
+        table_locations="unity_catalog",
+    )
+    db = _db(cfg)
+    with pytest.warns(UserWarning, match="Could not pin Delta version"):
+        db.pin_versions(spark)
+    # Unresolvable table is skipped, leaving the pin map empty (reads latest).
+    assert cfg.pinned_versions == {}

--- a/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
+++ b/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
@@ -32,18 +32,21 @@ def pin_schema(spark):  # noqa: F811
 
 def test_pin_versions_freezes_snapshot(spark, pin_schema):  # noqa: F811
     table = f"{pin_schema}.container_metrics"
+    # Build up two committed versions BEFORE pinning: v0 (3 rows) then v1 (5 rows).
     spark.range(3).toDF("container_id").write.format("delta").mode("overwrite").saveAsTable(table)
+    spark.range(3, 5).toDF("container_id").write.format("delta").mode("append").saveAsTable(table)
 
     cfg = MeasurementDBConfig(container_metrics_table=table, table_locations="unity_catalog")
     db = _db(cfg)
     db.pin_versions(spark)
-    assert cfg.pinned_versions == {table: 0}
+    # Must pin to the CURRENT (latest) version, not the oldest — v1, not v0.
+    assert cfg.pinned_versions == {table: 1}
 
     # Mutate the table AFTER pinning but BEFORE the (lazy) read materializes.
-    spark.range(3, 10).toDF("container_id").write.format("delta").mode("append").saveAsTable(table)
+    spark.range(5, 10).toDF("container_id").write.format("delta").mode("append").saveAsTable(table)
 
-    # The read still reflects the pinned snapshot, not the 10-row mutated table.
-    assert db.container_metrics(spark).count() == 3
+    # The read reflects the pinned v1 snapshot: not v0's 3 rows, not the mutated 10.
+    assert db.container_metrics(spark).count() == 5
 
     # Without a pin, the same read sees the latest snapshot.
     cfg.pinned_versions = {}
@@ -54,16 +57,19 @@ def test_pin_versions_freezes_snapshot_path_mode(spark, tmp_path):  # noqa: F811
     # Path mode (``external_locations``): reads and version resolution go through
     # the filesystem path rather than a catalog name.
     path = str(tmp_path / "container_metrics")
+    # Build up two committed versions BEFORE pinning: v0 (3 rows) then v1 (5 rows).
     spark.range(3).toDF("container_id").write.format("delta").mode("overwrite").save(path)
+    spark.range(3, 5).toDF("container_id").write.format("delta").mode("append").save(path)
 
     cfg = MeasurementDBConfig(container_metrics_table=path, table_locations="external_locations")
     db = _db(cfg)
     db.pin_versions(spark)
-    assert cfg.pinned_versions == {path: 0}
+    # Must pin to the CURRENT (latest) version, not the oldest — v1, not v0.
+    assert cfg.pinned_versions == {path: 1}
 
-    # Mutate after pinning; the pinned read must still see the original snapshot.
-    spark.range(3, 10).toDF("container_id").write.format("delta").mode("append").save(path)
-    assert db.container_metrics(spark).count() == 3
+    # Mutate after pinning; the pinned read must still see the v1 snapshot.
+    spark.range(5, 10).toDF("container_id").write.format("delta").mode("append").save(path)
+    assert db.container_metrics(spark).count() == 5
 
     cfg.pinned_versions = {}
     assert db.container_metrics(spark).count() == 10


### PR DESCRIPTION
## Summary

Report DataFrames are lazy, so every silver input read through
`MeasurementDB._read_table` (plain `spark.read.table(...)` in UC mode, or
`spark.read.format("delta").load(...)` in path mode) previously pinned no Delta
version. If an input table changed between when a run started and when a given
lazy op materialized, different stages of the same run could read different
snapshots, producing inconsistent results. This is easy to hit when reports run
while upstream ingestion is still writing.

This PR resolves each configured silver table's current Delta version once at
run start and reads every table with `versionAsOf`, so the whole run observes a
single consistent snapshot. Fixes #87.

## Changes

- Add `MeasurementDBConfig.pinned_versions` (URI to version; empty means "read
  latest", preserving existing behavior).
- Add `MeasurementDB.pin_versions(spark)`, which resolves the current Delta
  version of every configured silver table once via `DeltaTable.history(1)`.
- Update `MeasurementDB._read_table` to apply `.option("versionAsOf", v)` for
  both UC and path modes when a version is pinned.
- Call `self.db.pin_versions(self.spark)` at the start of
  `Report.determine_report()`, before any solving.
- Exempt debug (in-memory) mode. Non-Delta inputs, views, and unresolvable
  tables are skipped with a warning and keep reading latest, so deployments that
  use them are unaffected.

## Testing

- New `tests/impulse_query_engine/unit/measurement_db_versioning_test.py`:
  snapshot freezing (pin, append rows, assert the read still sees the pinned
  snapshot), debug-mode exemption, and graceful skip plus warning for
  unresolvable tables.
- Full query engine suite (935 passed) and a reporting integration test through
  the complete `determine_report` path both pass. `make lint` is clean.

## Test Plan

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Documentation updated (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No new linter warnings introduced
