### PR TITLE
Add scoped full recalculation to Impulse reporting

### DIFF
--- a/docs/impulse/docs/config/configuration.md
+++ b/docs/impulse/docs/config/configuration.md
@@ -354,6 +354,42 @@ mode-resolution rules and what counts as a definition change.
 
 ---
 
+## full_recalculation (optional)
+
+Forces a full recalculation of specific entities on an **incremental** run: the listed
+aggregations, events, and/or calculated channels recompute over **all** matching containers and
+have their gold rows fully replaced, regardless of whether their `definition_hash` changed. This is
+the same treatment a definition change already receives, applied on demand — useful to backfill
+after fixing a persistence bug or correcting upstream data, without rerunning everything in full
+mode. In full mode it is a no-op, since every entity already recomputes over all containers.
+
+Entities are identified by their human-readable `name`. A name that matches no registered entity
+fails the run fast with a `ValueError`, so typos surface immediately rather than silently doing
+nothing.
+
+| Field                 | Type        | Default | Description                                      |
+|-----------------------|-------------|---------|--------------------------------------------------|
+| `aggregations`        | `list[str]` | `[]`    | Names of aggregations to fully recompute.        |
+| `events`              | `list[str]` | `[]`    | Names of events to fully recompute.              |
+| `calculated_channels` | `list[str]` | `[]`    | Names of calculated channels to fully recompute. |
+
+```json
+{
+  "full_recalculation": {
+    "aggregations": ["rpm_hist_p1"],
+    "events": ["overspeed"],
+    "calculated_channels": ["power_kw"]
+  }
+}
+```
+
+:::note Incremental only
+`full_recalculation` only has an effect when the run is incremental. A first run, or any full run,
+already recomputes every entity over all containers, so the scope is ignored.
+:::
+
+---
+
 ## calculated_channels (optional)
 
 Controls the optional `calculated_channel_metrics` output. By default a report

--- a/docs/impulse/docs/references/api/impulse_reporting/config/config_parser.md
+++ b/docs/impulse/docs/references/api/impulse_reporting/config/config_parser.md
@@ -265,6 +265,33 @@ attribute key of the same name.
 registered KPI (see ``calculated_channel_kpis.KPI_BUILDERS``); an unknown
 name is rejected at validation. Duplicates are removed (order preserved).
 
+## FullRecalculation
+
+```python
+class FullRecalculation(BaseModel)
+```
+
+Scoped full-recalculation request, by entity name.
+
+Lists aggregations / events / calculated channels — identified by their
+human-readable ``name`` — that should be fully recalculated on the next run,
+regardless of whether their definition hash changed.
+
+Only meaningful in incremental mode: listed entities recompute over **all**
+containers and fully replace their gold rows (the same treatment a
+definition-hash change already receives), while every other entity stays
+incremental. In full mode this is a no-op, since everything recomputes over all
+containers anyway.
+
+Names that do not match any registered entity are rejected at the start of
+``Report.determine_report`` (fail fast on typos / stale names).
+
+**Arguments**:
+
+- `aggregations` (`list of str, default=[]`): Names of aggregations to fully recalculate.
+- `events` (`list of str, default=[]`): Names of events to fully recalculate.
+- `calculated_channels` (`list of str, default=[]`): Names of calculated channels to fully recalculate.
+
 ## ImpulseConfig
 
 ```python
@@ -288,6 +315,10 @@ Attributes
  calculated_channels : CalculatedChannels, optional
      Optional calculated-channel output configuration (e.g. opting in to the
      ``calculated_channel_metrics`` table). Defaults to CalculatedChannels().
+ full_recalculation : FullRecalculation, optional
+     Optional scoped full-recalculation request naming aggregations / events /
+     calculated channels to fully recompute on the next incremental run
+     regardless of definition-hash changes. Defaults to None (no override).
  measurement_dimensions : list of str, optional
      Column names to surface from ``container_metrics`` into the
      gold-layer ``measurement_dimension`` table. Names are matched

--- a/docs/impulse/docs/references/report/index.md
+++ b/docs/impulse/docs/references/report/index.md
@@ -119,6 +119,10 @@ Only the hashed attributes matter. Anything else is cosmetic and won't trigger r
 
 Renaming an aggregation, tweaking the description, or changing units keeps the hash stable. No reprocessing. `channel_names` (and a cross-channel statistic's `channel_name`) **do** affect the hash for `StatsAggregator` / `PointValueAggregator`, because they are the fact table's `channel_name` merge key — renaming forces a recompute so old-name rows are pruned rather than left stale.
 
+#### Forcing a full recalculation
+
+To recompute specific entities over all containers even when their `definition_hash` is unchanged, list their names under [`full_recalculation`](../../config/configuration.md#full_recalculation-optional) in config. The listed aggregations, events, and calculated channels are treated as **changed** for that run — they recompute over all matching containers and their gold rows are fully replaced — while every other entity stays incremental. This is meant for backfills after a persistence fix or corrected upstream data. In full mode it is a no-op, and a name that matches no registered entity fails the run fast.
+
 #### Container-update detection
 
 `ContainerUpsertDetector.detect_upserted_containers` finds two things and unions them:

--- a/skills/impulse-config/SKILL.md
+++ b/skills/impulse-config/SKILL.md
@@ -6,7 +6,7 @@ description: >
   "configure an Impulse report", set the source/sink tables, filter which containers are processed,
   choose RLE vs RAW, turn on incremental processing, run without writing (sinkless), remap column
   names, or scope by project. Covers source, unity_sink, container_filters, query_engine, solver_config,
-  incremental, measurement_dimensions, and calculated_channels, all validated by Pydantic.
+  incremental, full_recalculation, measurement_dimensions, and calculated_channels, all validated by Pydantic.
 ---
 
 # Impulse — configuration
@@ -40,6 +40,7 @@ config = {
         ],
     },
     "incremental": {"enabled": True},
+    "full_recalculation": {"aggregations": ["rpm_hist_p1"]},  # optional
     "measurement_dimensions": ["container_id", "vehicle_key", "start_ts", "stop_ts"],
     "calculated_channels": {"emit_channel_metrics": True, "attribute_columns": ["unit"]},  # optional
 }
@@ -167,6 +168,22 @@ Reuses prior results for unchanged definitions and reprocesses only new/updated 
 | `enabled`                     | `false`         | Turn incremental processing on.                 |
 | `silver_last_modified_column` | `"timestamp"`   | Silver column used to detect container updates. |
 | `gold_last_modified_column`   | `"_created_at"` | Gold column used to detect prior-run freshness. |
+
+## full_recalculation (optional)
+
+Forces a full recalculation of specific entities on an **incremental** run: the listed aggregations,
+events, and/or calculated channels recompute over **all** matching containers and have their gold rows
+fully replaced, even when their `definition_hash` is unchanged (the same treatment a definition change
+already receives, applied on demand). Use it to backfill after fixing a persistence bug or correcting
+upstream data, without a full-mode rerun of everything. In full mode it is a no-op — everything already
+recomputes. Entities are named by their human-readable `name`; a name matching no registered entity
+fails the run fast with a `ValueError`, so typos surface immediately.
+
+| Field                 | Default | Description                                    |
+|-----------------------|---------|------------------------------------------------|
+| `aggregations`        | `[]`    | Names of aggregations to fully recompute.      |
+| `events`              | `[]`    | Names of events to fully recompute.            |
+| `calculated_channels` | `[]`    | Names of calculated channels to fully recompute. |
 
 ## measurement_dimensions (optional)
 

--- a/skills/impulse-reporting/SKILL.md
+++ b/skills/impulse-reporting/SKILL.md
@@ -122,6 +122,12 @@ definitions reprocess only new/updated containers (persisted via Delta `MERGE` o
 changed or brand-new definitions reprocess all matching containers (replaced atomically via
 `replaceWhere` on `visual_id`/`event_id`/`channel_id`). A single run can mix both per entity.
 
+**Forcing a full recalculation.** To recompute specific *unchanged* entities over all containers — e.g.
+to backfill after a persistence fix or corrected upstream data — list their names under
+`full_recalculation` in config (see `impulse-config`). Those aggregations/events/calculated channels are
+treated as changed for that run regardless of their hash; everything else stays incremental. A no-op in
+full mode, and a name matching no registered entity fails fast.
+
 **What counts as a definition change** — only the hashed attributes; renames, descriptions, and units
 are cosmetic and do not trigger reprocessing:
 

--- a/src/impulse_reporting/config/config_parser.py
+++ b/src/impulse_reporting/config/config_parser.py
@@ -500,6 +500,38 @@ class CalculatedChannels(BaseModel):
         return normalized
 
 
+class FullRecalculation(BaseModel):
+    """
+    Scoped full-recalculation request, by entity name.
+
+    Lists aggregations / events / calculated channels — identified by their
+    human-readable ``name`` — that should be fully recalculated on the next run,
+    regardless of whether their definition hash changed.
+
+    Only meaningful in incremental mode: listed entities recompute over **all**
+    containers and fully replace their gold rows (the same treatment a
+    definition-hash change already receives), while every other entity stays
+    incremental. In full mode this is a no-op, since everything recomputes over all
+    containers anyway.
+
+    Names that do not match any registered entity are rejected at the start of
+    ``Report.determine_report`` (fail fast on typos / stale names).
+
+    Attributes
+    ----------
+    aggregations : list of str, default=[]
+        Names of aggregations to fully recalculate.
+    events : list of str, default=[]
+        Names of events to fully recalculate.
+    calculated_channels : list of str, default=[]
+        Names of calculated channels to fully recalculate.
+    """
+
+    aggregations: list[str] = []
+    events: list[str] = []
+    calculated_channels: list[str] = []
+
+
 class ImpulseConfig(BaseModel):
     """
      Main configuration model.
@@ -519,6 +551,10 @@ class ImpulseConfig(BaseModel):
      calculated_channels : CalculatedChannels, optional
          Optional calculated-channel output configuration (e.g. opting in to the
          ``calculated_channel_metrics`` table). Defaults to CalculatedChannels().
+     full_recalculation : FullRecalculation, optional
+         Optional scoped full-recalculation request naming aggregations / events /
+         calculated channels to fully recompute on the next incremental run
+         regardless of definition-hash changes. Defaults to None (no override).
      measurement_dimensions : list of str, optional
          Column names to surface from ``container_metrics`` into the
          gold-layer ``measurement_dimension`` table. Names are matched
@@ -594,6 +630,7 @@ class ImpulseConfig(BaseModel):
     query_engine: QueryEngine = QueryEngine(solver=Solvers.DEFAULT_SOLVER)
     incremental: IncrementalConfig | None = None
     calculated_channels: CalculatedChannels = CalculatedChannels()
+    full_recalculation: FullRecalculation | None = None
 
     measurement_dimensions: list[str] = list(DEFAULT_MEASUREMENT_DIMENSIONS)
 

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -28,6 +28,7 @@ from impulse_reporting.core.report_utils import (
     dispatch_calculated_channel_metrics,
     dispatch_calculated_channels,
     dispatch_events,
+    full_recalc_names,
     group_selectables_by_type,
     merge_changed_unchanged,
     persist_channel_metrics,
@@ -35,9 +36,11 @@ from impulse_reporting.core.report_utils import (
     persist_dimensions_incremental,
     persist_facts_full,
     persist_facts_incremental,
+    registered_names_by_kind,
     solve_calculated_channels_batched,
     solve_expressions_batched,
     split_by_hash_change,
+    validate_full_recalculation_scope,
 )
 from impulse_reporting.events.container_event import ContainerEvent
 from impulse_reporting.events.event import Event
@@ -549,66 +552,28 @@ class Report:
             )
             raise ValueError(error_message)
 
-    def _registered_names(self, kind: str) -> list[str]:
-        """Names of registered entities of *kind* (``"event"``/``"aggregation"``/``"channel"``)."""
-        if kind == "event":
-            return [event.get_name() for event in self.events]
-        if kind == "aggregation":
-            return [agg.get_name() for page in self.pages for agg in page.aggregations]
-        if kind == "channel":
-            return [channel.get_name() for channel in self.calculated_channels]
-        raise ValueError(f"Unsupported kind '{kind}'.")
-
-    def _full_recalc_names(self, kind: str) -> set[str]:
-        """Names configured for scoped full recalculation for *kind*.
-
-        Returns an empty set when no ``full_recalculation`` config is present.
-        """
-        cfg = getattr(self.config, "full_recalculation", None) if hasattr(self, "config") else None
-        if cfg is None:
-            return set()
-        by_kind = {
-            "event": cfg.events,
-            "aggregation": cfg.aggregations,
-            "channel": cfg.calculated_channels,
-        }
-        return set(by_kind[kind])
-
     def _validate_full_recalculation_scope(self) -> None:
         """Reject full-recalculation names that match no registered entity.
 
-        Fails fast (mirroring :meth:`_validate_aggregation_events`) so typos or
-        stale names surface immediately rather than silently recomputing nothing.
+        Thin wrapper delegating to :func:`report_utils.validate_full_recalculation_scope`;
+        supplies the report's registered entity names. Fails fast (mirroring
+        :meth:`_validate_aggregation_events`) so typos or stale names surface
+        immediately rather than silently recomputing nothing.
 
         Raises
         ------
         ValueError
             If any configured name does not match a registered entity of its kind.
         """
-        cfg = getattr(self.config, "full_recalculation", None) if hasattr(self, "config") else None
-        if cfg is None:
-            return
-
-        problems: list[str] = []
-        for kind, label in (
-            ("aggregation", "aggregations"),
-            ("event", "events"),
-            ("channel", "calculated channels"),
-        ):
-            requested = self._full_recalc_names(kind)
-            registered = set(self._registered_names(kind))
-            unknown = sorted(requested - registered)
-            if unknown:
-                valid = ", ".join(sorted(registered)) or "(none registered)"
-                problems.append(
-                    f"{label}: {unknown} not registered on the report. Valid names: {valid}."
-                )
-
-        if problems:
-            raise ValueError(
-                "full_recalculation names must match registered entities:\n"
-                + "\n".join(f"  - {msg}" for msg in problems)
-            )
+        validate_full_recalculation_scope(
+            self.config,
+            registered_names_by_kind(
+                self.get_events(),
+                [agg for page in self.pages for agg in page.aggregations],
+                self.get_calculated_channels(),
+            ),
+            ["aggregation", "event", "channel"],
+        )
 
     @telemetry_logger("report", "persist_results")
     def persist_results(self, cleanup_temp_tables: bool | None = None):
@@ -1052,7 +1017,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="event",
-                force_recalc_names=self._full_recalc_names("event"),
+                force_recalc_names=full_recalc_names(self.config, "event"),
             )
         )
         changed_aggs_by_type, unchanged_aggs_by_type, self._changed_aggregation_ids = (
@@ -1063,7 +1028,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="aggregation",
-                force_recalc_names=self._full_recalc_names("aggregation"),
+                force_recalc_names=full_recalc_names(self.config, "aggregation"),
             )
         )
 
@@ -1144,7 +1109,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="channel",
-                force_recalc_names=self._full_recalc_names("channel"),
+                force_recalc_names=full_recalc_names(self.config, "channel"),
             )
         )
         # Collect the query-engine channel expressions across types for the batched

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -549,6 +549,67 @@ class Report:
             )
             raise ValueError(error_message)
 
+    def _registered_names(self, kind: str) -> list[str]:
+        """Names of registered entities of *kind* (``"event"``/``"aggregation"``/``"channel"``)."""
+        if kind == "event":
+            return [event.get_name() for event in self.events]
+        if kind == "aggregation":
+            return [agg.get_name() for page in self.pages for agg in page.aggregations]
+        if kind == "channel":
+            return [channel.get_name() for channel in self.calculated_channels]
+        raise ValueError(f"Unsupported kind '{kind}'.")
+
+    def _full_recalc_names(self, kind: str) -> set[str]:
+        """Names configured for scoped full recalculation for *kind*.
+
+        Returns an empty set when no ``full_recalculation`` config is present.
+        """
+        cfg = getattr(self.config, "full_recalculation", None) if hasattr(self, "config") else None
+        if cfg is None:
+            return set()
+        by_kind = {
+            "event": cfg.events,
+            "aggregation": cfg.aggregations,
+            "channel": cfg.calculated_channels,
+        }
+        return set(by_kind[kind])
+
+    def _validate_full_recalculation_scope(self) -> None:
+        """Reject full-recalculation names that match no registered entity.
+
+        Fails fast (mirroring :meth:`_validate_aggregation_events`) so typos or
+        stale names surface immediately rather than silently recomputing nothing.
+
+        Raises
+        ------
+        ValueError
+            If any configured name does not match a registered entity of its kind.
+        """
+        cfg = getattr(self.config, "full_recalculation", None) if hasattr(self, "config") else None
+        if cfg is None:
+            return
+
+        problems: list[str] = []
+        for kind, label in (
+            ("aggregation", "aggregations"),
+            ("event", "events"),
+            ("channel", "calculated channels"),
+        ):
+            requested = self._full_recalc_names(kind)
+            registered = set(self._registered_names(kind))
+            unknown = sorted(requested - registered)
+            if unknown:
+                valid = ", ".join(sorted(registered)) or "(none registered)"
+                problems.append(
+                    f"{label}: {unknown} not registered on the report. Valid names: {valid}."
+                )
+
+        if problems:
+            raise ValueError(
+                "full_recalculation names must match registered entities:\n"
+                + "\n".join(f"  - {msg}" for msg in problems)
+            )
+
     @telemetry_logger("report", "persist_results")
     def persist_results(self, cleanup_temp_tables: bool | None = None):
         """
@@ -937,6 +998,9 @@ class Report:
         # Validate that every aggregation references a registered event
         self._validate_aggregation_events()
 
+        # Validate that any scoped full-recalculation names match registered entities
+        self._validate_full_recalculation_scope()
+
         # Pin one consistent Delta snapshot of every configured silver input for
         # the whole run so mid-run table changes cannot leak across lazy stages
         # (issue #87).
@@ -982,7 +1046,13 @@ class Report:
         # Split changed/unchanged definitions
         changed_events_by_type, unchanged_events_by_type, self._changed_event_ids = (
             split_by_hash_change(
-                events_by_type, EventType, self.sink, self.spark, hash_comparator, kind="event"
+                events_by_type,
+                EventType,
+                self.sink,
+                self.spark,
+                hash_comparator,
+                kind="event",
+                force_recalc_names=self._full_recalc_names("event"),
             )
         )
         changed_aggs_by_type, unchanged_aggs_by_type, self._changed_aggregation_ids = (
@@ -993,6 +1063,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="aggregation",
+                force_recalc_names=self._full_recalc_names("aggregation"),
             )
         )
 
@@ -1073,6 +1144,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="channel",
+                force_recalc_names=self._full_recalc_names("channel"),
             )
         )
         # Collect the query-engine channel expressions across types for the batched

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -36,7 +36,6 @@ from impulse_reporting.core.report_utils import (
     persist_dimensions_incremental,
     persist_facts_full,
     persist_facts_incremental,
-    registered_names_by_kind,
     solve_calculated_channels_batched,
     solve_expressions_batched,
     split_by_hash_change,
@@ -567,11 +566,11 @@ class Report:
         """
         validate_full_recalculation_scope(
             self.config,
-            registered_names_by_kind(
-                self.get_events(),
-                [agg for page in self.pages for agg in page.aggregations],
-                self.get_calculated_channels(),
-            ),
+            {
+                "events": self.get_events(),
+                "aggregations": [agg for page in self.pages for agg in page.aggregations],
+                "calculated_channels": self.get_calculated_channels(),
+            },
         )
 
     @telemetry_logger("report", "persist_results")
@@ -1016,7 +1015,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="event",
-                force_recalc_names=full_recalc_names(self.config, "event"),
+                force_recalc_names=full_recalc_names(self.config, "events"),
             )
         )
         changed_aggs_by_type, unchanged_aggs_by_type, self._changed_aggregation_ids = (
@@ -1027,7 +1026,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="aggregation",
-                force_recalc_names=full_recalc_names(self.config, "aggregation"),
+                force_recalc_names=full_recalc_names(self.config, "aggregations"),
             )
         )
 
@@ -1108,7 +1107,7 @@ class Report:
                 self.spark,
                 hash_comparator,
                 kind="channel",
-                force_recalc_names=full_recalc_names(self.config, "channel"),
+                force_recalc_names=full_recalc_names(self.config, "calculated_channels"),
             )
         )
         # Collect the query-engine channel expressions across types for the batched

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -572,7 +572,6 @@ class Report:
                 [agg for page in self.pages for agg in page.aggregations],
                 self.get_calculated_channels(),
             ),
-            ["aggregation", "event", "channel"],
         )
 
     @telemetry_logger("report", "persist_results")

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     )
     from impulse_query_engine.analyze.query.query_builder import QueryBuilder
     from impulse_query_engine.analyze.query.solvers.query_solver import QuerySolver
+    from impulse_reporting.config.config_parser import ImpulseConfig
     from impulse_reporting.incremental.definition_hash_comparator import (
         DefinitionHashComparator,
     )
@@ -197,6 +198,109 @@ def split_by_hash_change(
             unchanged_by_type[type_name] = unchanged
 
     return changed_by_type, unchanged_by_type, changed_ids
+
+
+def full_recalc_names(config: ImpulseConfig, kind: str) -> set[str]:
+    """Names configured for scoped full recalculation for *kind*.
+
+    Parameters
+    ----------
+    config : ImpulseConfig
+        The report config; its optional ``full_recalculation`` field holds the
+        per-kind name lists.
+    kind : str
+        One of ``"event"``, ``"aggregation"``, or ``"channel"``.
+
+    Returns
+    -------
+    set[str]
+        The configured names, or an empty set when no ``full_recalculation``
+        config is present.
+    """
+    cfg = getattr(config, "full_recalculation", None)
+    if cfg is None:
+        return set()
+    by_kind = {
+        "event": cfg.events,
+        "aggregation": cfg.aggregations,
+        "channel": cfg.calculated_channels,
+    }
+    return set(by_kind[kind])
+
+
+def registered_names_by_kind(
+    events: list,
+    aggregations: list,
+    calculated_channels: list,
+) -> dict[str, list[str]]:
+    """Map each scoped-recalc kind to the ``get_name()`` of its registered entities.
+
+    Parameters
+    ----------
+    events : list
+        Registered events.
+    aggregations : list
+        Registered aggregations (already flattened across pages).
+    calculated_channels : list
+        Registered calculated channels.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        ``{"event": [...], "aggregation": [...], "channel": [...]}``.
+    """
+    return {
+        "event": [event.get_name() for event in events],
+        "aggregation": [agg.get_name() for agg in aggregations],
+        "channel": [channel.get_name() for channel in calculated_channels],
+    }
+
+
+def validate_full_recalculation_scope(
+    config: ImpulseConfig,
+    registered_names: dict[str, list[str]],
+    kinds: list[str],
+) -> None:
+    """Reject full-recalculation names that match no registered entity.
+
+    Fails fast so typos or stale names surface immediately rather than silently
+    recomputing nothing. A no-op when no ``full_recalculation`` config is present.
+
+    Parameters
+    ----------
+    config : ImpulseConfig
+        The report config carrying the optional ``full_recalculation`` scope.
+    registered_names : dict[str, list[str]]
+        ``{kind: [names]}`` of the entities registered on the report, as produced
+        by :func:`registered_names_by_kind`.
+    kinds : list[str]
+        The entity kinds to validate (e.g. ``["aggregation", "event", "channel"]``);
+        each must be one of those accepted by :func:`split_by_hash_change`.
+
+    Raises
+    ------
+    ValueError
+        If any configured name does not match a registered entity of its kind.
+    """
+    if getattr(config, "full_recalculation", None) is None:
+        return
+
+    problems: list[str] = []
+    for kind in kinds:
+        requested = full_recalc_names(config, kind)
+        registered = set(registered_names.get(kind, []))
+        unknown = sorted(requested - registered)
+        if unknown:
+            valid = ", ".join(sorted(registered)) or "(none registered)"
+            problems.append(
+                f"{kind}: {unknown} not registered on the report. Valid names: {valid}."
+            )
+
+    if problems:
+        raise ValueError(
+            "full_recalculation names must match registered entities:\n"
+            + "\n".join(f"  - {msg}" for msg in problems)
+        )
 
 
 def collect_solvable_expressions(

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -122,6 +122,7 @@ def split_by_hash_change(
     spark: SparkSession,
     hash_comparator: DefinitionHashComparator,
     kind: str = "event",
+    force_recalc_names: set[str] | None = None,
 ) -> tuple[dict[str, list], dict[str, list], dict[str, list[int]]]:
     """Split items into changed/unchanged using definition-hash comparison.
 
@@ -140,6 +141,11 @@ def split_by_hash_change(
     kind : str
         One of ``"event"``, ``"aggregation"``, or ``"channel"`` — selects which
         comparator method to use.
+    force_recalc_names : set[str] | None
+        Names (``item.get_name()``) of items to force into the "changed" bucket
+        regardless of their definition hash. Used for scoped full recalculation:
+        a forced item recomputes over all containers and fully replaces its gold
+        rows, exactly as a hash change would. ``None``/empty is a no-op.
 
     Returns
     -------
@@ -154,6 +160,8 @@ def split_by_hash_change(
     if kind not in comparators:
         raise ValueError(f"Unsupported kind '{kind}'; expected one of {sorted(comparators)}.")
     compare = comparators[kind]
+
+    forced_names = force_recalc_names or set()
 
     changed_by_type: dict[str, list] = {}
     unchanged_by_type: dict[str, list] = {}
@@ -171,6 +179,16 @@ def split_by_hash_change(
 
         dim_table = sink.config.get_output_uri_dimension_table(type_enum[type_name])
         changed, unchanged = compare(items, dim_table)
+
+        # Scoped full recalc: promote hash-unchanged items whose name is in scope
+        # into the changed bucket so they recompute over all containers.
+        if forced_names and unchanged:
+            forced, still_unchanged = [], []
+            for item in unchanged:
+                (forced if item.get_name() in forced_names else still_unchanged).append(item)
+            if forced:
+                changed = changed + forced
+                unchanged = still_unchanged
 
         if changed:
             changed_by_type[type_name] = changed

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -217,7 +217,7 @@ def full_recalc_names(config: ImpulseConfig, kind: str) -> set[str]:
         The configured names, or an empty set when no ``full_recalculation``
         config is present.
     """
-    cfg = getattr(config, "full_recalculation", None)
+    cfg = config.full_recalculation
     if cfg is None:
         return set()
     by_kind = {
@@ -279,7 +279,7 @@ def validate_full_recalculation_scope(
     ValueError
         If any configured name does not match a registered entity of its kind.
     """
-    if getattr(config, "full_recalculation", None) is None:
+    if config.full_recalculation is None:
         return
 
     problems: list[str] = []

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -259,7 +259,6 @@ def registered_names_by_kind(
 def validate_full_recalculation_scope(
     config: ImpulseConfig,
     registered_names: dict[str, list[str]],
-    kinds: list[str],
 ) -> None:
     """Reject full-recalculation names that match no registered entity.
 
@@ -272,9 +271,7 @@ def validate_full_recalculation_scope(
         The report config carrying the optional ``full_recalculation`` scope.
     registered_names : dict[str, list[str]]
         ``{kind: [names]}`` of the entities registered on the report, as produced
-        by :func:`registered_names_by_kind`.
-    kinds : list[str]
-        The entity kinds to validate (e.g. ``["aggregation", "event", "channel"]``);
+        by :func:`registered_names_by_kind`. Its keys are the kinds validated —
         each must be one of those accepted by :func:`split_by_hash_change`.
 
     Raises
@@ -286,9 +283,9 @@ def validate_full_recalculation_scope(
         return
 
     problems: list[str] = []
-    for kind in kinds:
+    for kind, registered_for_kind in registered_names.items():
         requested = full_recalc_names(config, kind)
-        registered = set(registered_names.get(kind, []))
+        registered = set(registered_for_kind)
         unknown = sorted(requested - registered)
         if unknown:
             valid = ", ".join(sorted(registered)) or "(none registered)"

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -209,7 +209,8 @@ def full_recalc_names(config: ImpulseConfig, kind: str) -> set[str]:
         The report config; its optional ``full_recalculation`` field holds the
         per-kind name lists.
     kind : str
-        One of ``"event"``, ``"aggregation"``, or ``"channel"``.
+        The ``FullRecalculation`` field to read — one of ``"events"``,
+        ``"aggregations"``, or ``"calculated_channels"``.
 
     Returns
     -------
@@ -220,59 +221,30 @@ def full_recalc_names(config: ImpulseConfig, kind: str) -> set[str]:
     cfg = config.full_recalculation
     if cfg is None:
         return set()
-    by_kind = {
-        "event": cfg.events,
-        "aggregation": cfg.aggregations,
-        "channel": cfg.calculated_channels,
-    }
-    return set(by_kind[kind])
-
-
-def registered_names_by_kind(
-    events: list,
-    aggregations: list,
-    calculated_channels: list,
-) -> dict[str, list[str]]:
-    """Map each scoped-recalc kind to the ``get_name()`` of its registered entities.
-
-    Parameters
-    ----------
-    events : list
-        Registered events.
-    aggregations : list
-        Registered aggregations (already flattened across pages).
-    calculated_channels : list
-        Registered calculated channels.
-
-    Returns
-    -------
-    dict[str, list[str]]
-        ``{"event": [...], "aggregation": [...], "channel": [...]}``.
-    """
-    return {
-        "event": [event.get_name() for event in events],
-        "aggregation": [agg.get_name() for agg in aggregations],
-        "channel": [channel.get_name() for channel in calculated_channels],
-    }
+    return set(getattr(cfg, kind))
 
 
 def validate_full_recalculation_scope(
     config: ImpulseConfig,
-    registered_names: dict[str, list[str]],
+    registered_entities: dict[str, list],
 ) -> None:
     """Reject full-recalculation names that match no registered entity.
 
     Fails fast so typos or stale names surface immediately rather than silently
     recomputing nothing. A no-op when no ``full_recalculation`` config is present.
 
+    Kind-agnostic: the caller owns the set of kinds and their entity lists, so the
+    valid kinds live in one place (the call site) rather than being hardcoded here.
+
     Parameters
     ----------
     config : ImpulseConfig
         The report config carrying the optional ``full_recalculation`` scope.
-    registered_names : dict[str, list[str]]
-        ``{kind: [names]}`` of the entities registered on the report, as produced
-        by :func:`registered_names_by_kind`. Its keys are the kinds validated —
-        each must be one of those accepted by :func:`split_by_hash_change`.
+    registered_entities : dict[str, list]
+        ``{kind: [entities]}`` registered on the report; each entity must expose
+        ``get_name()``. The keys are the kinds validated and must be
+        ``FullRecalculation`` field names (``"events"``, ``"aggregations"``,
+        ``"calculated_channels"``), so :func:`full_recalc_names` can read them.
 
     Raises
     ------
@@ -283,9 +255,9 @@ def validate_full_recalculation_scope(
         return
 
     problems: list[str] = []
-    for kind, registered_for_kind in registered_names.items():
+    for kind, entities in registered_entities.items():
         requested = full_recalc_names(config, kind)
-        registered = set(registered_for_kind)
+        registered = {entity.get_name() for entity in entities}
         unknown = sorted(requested - registered)
         if unknown:
             valid = ", ".join(sorted(registered)) or "(none registered)"

--- a/tests/impulse_reporting/integration/incremental_report_test.py
+++ b/tests/impulse_reporting/integration/incremental_report_test.py
@@ -3,6 +3,7 @@ from unittest.mock import create_autospec
 import pyspark.sql.functions as F
 import pyspark.sql.types as T
 from databricks.sdk import WorkspaceClient
+from pyspark.sql import Window
 
 from impulse_reporting.aggregations.histogram import (
     HistogramDuration,
@@ -11,6 +12,7 @@ from impulse_reporting.aggregations.point_value_aggregator import PointValueAggr
 from impulse_reporting.aggregations.stats_aggregator import StatsAggregator
 from impulse_reporting.channels.calculated_channel import CalculatedChannel
 from impulse_reporting.config.config_parser import (
+    FullRecalculation,
     IncrementalConfig,
     ImpulseConfig,
     Source,
@@ -469,6 +471,122 @@ def test_incremental_in_report_case_5(spark):
 
     assert agg_pre_count == 12  # 3 aggregations x 2 files
     assert agg_post_count == 27  # 9 aggregations x 3 files
+
+
+def test_incremental_scoped_full_recalculation(spark):
+    """Scoped full recalculation forces a hash-unchanged aggregation to recompute
+    over ALL containers (replacing its gold rows), while a non-listed unchanged
+    aggregation sharing the same fact table is left untouched.
+
+    Setup that isolates the feature from ordinary incremental triggers: container
+    2's channel data is shrunk in silver, but every container's ``timestamp`` is
+    set to the past so container-update detection flags nothing. Without the
+    scope, nothing would be recomputed. With ``rpm_hist_p1`` in
+    ``full_recalculation``, only that histogram is recomputed for all containers.
+    """
+    # --- Run 1 (full): populate gold from the standard 2-container silver ---
+    report_1: Report = Report(
+        name="my_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(set_config("container_metrics_inc_1_2", False)),
+    )
+    add_aggs_to_report(report_1)
+    report_1.determine_report()
+    report_1.persist_results()
+
+    hist_dim = spark.read.table("spark_catalog.gold.evaluation_histogram_dimension")
+    rpm_vid = hist_dim.where(F.col("name") == "rpm_hist_p1").select("visual_id").collect()[0][0]
+    speed_vid = (
+        hist_dim.where(F.col("name") == "speed_hist_p1").select("visual_id").collect()[0][0]
+    )
+
+    hist_fact_pre = spark.read.table("spark_catalog.gold.evaluation_histogram_fact")
+
+    def _rpm_sum(df, container_id):
+        return (
+            df.where((F.col("visual_id") == rpm_vid) & (F.col("container_id") == container_id))
+            .agg(F.sum("hist_value"))
+            .collect()[0][0]
+        )
+
+    rpm_c1_sum_pre = _rpm_sum(hist_fact_pre, 1)
+    rpm_c2_sum_pre = _rpm_sum(hist_fact_pre, 2)
+    speed_c2_rows_pre = (
+        hist_fact_pre.where((F.col("visual_id") == speed_vid) & (F.col("container_id") == 2))
+        .orderBy("bin_id")
+        .collect()
+    )
+    assert rpm_c2_sum_pre > 0
+    assert len(speed_c2_rows_pre) > 0
+
+    # --- Build scratch silver: shrink container 2's channels, no container flagged updated ---
+    cm_scratch = "spark_catalog.silver.container_metrics_scoped_recalc"
+    ch_scratch = "spark_catalog.silver.channels_scoped_recalc"
+
+    # Every timestamp is in the past -> silver older than gold _created_at -> no updates detected.
+    spark.read.table("spark_catalog.silver.container_metrics_inc_1_2").withColumn(
+        "timestamp", F.lit("2020-01-01 00:00:00").cast("timestamp")
+    ).write.format("delta").mode("overwrite").saveAsTable(cm_scratch)
+
+    # Keep only the earliest 5 samples per channel for container 2; all other rows unchanged.
+    rn = F.row_number().over(Window.partitionBy("container_id", "channel_id").orderBy("tstart"))
+    spark.read.table("spark_catalog.silver.channels").withColumn("_rn", rn).filter(
+        (F.col("container_id") != 2) | (F.col("_rn") <= 5)
+    ).drop("_rn").write.format("delta").mode("overwrite").saveAsTable(ch_scratch)
+
+    # --- Run 2 (incremental) with scoped full recalc of rpm_hist_p1 only ---
+    config_2 = ImpulseConfig(
+        source=Source(
+            container_metrics_table=cm_scratch,
+            channel_metrics_table="spark_catalog.silver.channel_metrics",
+            channels_uri=ch_scratch,
+        ),
+        unity_sink=UnitySink(
+            catalog="spark_catalog",
+            schema="gold",
+            table_prefix="evaluation",
+        ),
+        incremental=IncrementalConfig(
+            enabled=True,
+            silver_last_modified_column="timestamp",
+            gold_last_modified_column="_created_at",
+        ),
+        full_recalculation=FullRecalculation(aggregations=["rpm_hist_p1"]),
+    )
+    report_2: Report = Report(
+        name="my_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(config_2),
+    )
+    add_aggs_to_report(report_2)
+    report_2.determine_report()
+    report_2.persist_results()
+
+    hist_fact_post = spark.read.table("spark_catalog.gold.evaluation_histogram_fact")
+
+    rpm_c1_sum_post = _rpm_sum(hist_fact_post, 1)
+    rpm_c2_sum_post = _rpm_sum(hist_fact_post, 2)
+    speed_c2_rows_post = (
+        hist_fact_post.where((F.col("visual_id") == speed_vid) & (F.col("container_id") == 2))
+        .orderBy("bin_id")
+        .collect()
+    )
+
+    # rpm_hist_p1 was recomputed over ALL containers using the shrunk channels:
+    # container 2's shrunk data yields a smaller (but still positive) total duration.
+    assert rpm_c2_sum_post > 0
+    assert rpm_c2_sum_post < rpm_c2_sum_pre, (
+        "Forced full recalc must recompute rpm_hist_p1 for container 2 (unmodified "
+        "timestamp) against the shrunk silver data"
+    )
+    # container 1's data is unchanged, so its recomputed values match.
+    assert rpm_c1_sum_post == rpm_c1_sum_pre
+
+    # speed_hist_p1 is neither listed nor on an updated container -> its gold rows
+    # are preserved untouched, even though it shares the histogram_fact table.
+    assert speed_c2_rows_post == speed_c2_rows_pre
 
 
 def add_aggs_to_report(my_report):

--- a/tests/impulse_reporting/integration/incremental_report_test.py
+++ b/tests/impulse_reporting/integration/incremental_report_test.py
@@ -524,69 +524,75 @@ def test_incremental_scoped_full_recalculation(spark):
     cm_scratch = "spark_catalog.silver.container_metrics_scoped_recalc"
     ch_scratch = "spark_catalog.silver.channels_scoped_recalc"
 
-    # Every timestamp is in the past -> silver older than gold _created_at -> no updates detected.
-    spark.read.table("spark_catalog.silver.container_metrics_inc_1_2").withColumn(
-        "timestamp", F.lit("2020-01-01 00:00:00").cast("timestamp")
-    ).write.format("delta").mode("overwrite").saveAsTable(cm_scratch)
+    try:
+        # Every timestamp is in the past -> silver older than gold _created_at -> no updates.
+        spark.read.table("spark_catalog.silver.container_metrics_inc_1_2").withColumn(
+            "timestamp", F.lit("2020-01-01 00:00:00").cast("timestamp")
+        ).write.format("delta").mode("overwrite").saveAsTable(cm_scratch)
 
-    # Keep only the earliest 5 samples per channel for container 2; all other rows unchanged.
-    rn = F.row_number().over(Window.partitionBy("container_id", "channel_id").orderBy("tstart"))
-    spark.read.table("spark_catalog.silver.channels").withColumn("_rn", rn).filter(
-        (F.col("container_id") != 2) | (F.col("_rn") <= 5)
-    ).drop("_rn").write.format("delta").mode("overwrite").saveAsTable(ch_scratch)
+        # Keep only the earliest 5 samples per channel for container 2; all other rows unchanged.
+        rn = F.row_number().over(
+            Window.partitionBy("container_id", "channel_id").orderBy("tstart")
+        )
+        spark.read.table("spark_catalog.silver.channels").withColumn("_rn", rn).filter(
+            (F.col("container_id") != 2) | (F.col("_rn") <= 5)
+        ).drop("_rn").write.format("delta").mode("overwrite").saveAsTable(ch_scratch)
 
-    # --- Run 2 (incremental) with scoped full recalc of rpm_hist_p1 only ---
-    config_2 = ImpulseConfig(
-        source=Source(
-            container_metrics_table=cm_scratch,
-            channel_metrics_table="spark_catalog.silver.channel_metrics",
-            channels_uri=ch_scratch,
-        ),
-        unity_sink=UnitySink(
-            catalog="spark_catalog",
-            schema="gold",
-            table_prefix="evaluation",
-        ),
-        incremental=IncrementalConfig(
-            enabled=True,
-            silver_last_modified_column="timestamp",
-            gold_last_modified_column="_created_at",
-        ),
-        full_recalculation=FullRecalculation(aggregations=["rpm_hist_p1"]),
-    )
-    report_2: Report = Report(
-        name="my_report",
-        spark=spark,
-        workspace_client=create_autospec(WorkspaceClient),
-        config=dict(config_2),
-    )
-    add_aggs_to_report(report_2)
-    report_2.determine_report()
-    report_2.persist_results()
+        # --- Run 2 (incremental) with scoped full recalc of rpm_hist_p1 only ---
+        config_2 = ImpulseConfig(
+            source=Source(
+                container_metrics_table=cm_scratch,
+                channel_metrics_table="spark_catalog.silver.channel_metrics",
+                channels_uri=ch_scratch,
+            ),
+            unity_sink=UnitySink(
+                catalog="spark_catalog",
+                schema="gold",
+                table_prefix="evaluation",
+            ),
+            incremental=IncrementalConfig(
+                enabled=True,
+                silver_last_modified_column="timestamp",
+                gold_last_modified_column="_created_at",
+            ),
+            full_recalculation=FullRecalculation(aggregations=["rpm_hist_p1"]),
+        )
+        report_2: Report = Report(
+            name="my_report",
+            spark=spark,
+            workspace_client=create_autospec(WorkspaceClient),
+            config=dict(config_2),
+        )
+        add_aggs_to_report(report_2)
+        report_2.determine_report()
+        report_2.persist_results()
 
-    hist_fact_post = spark.read.table("spark_catalog.gold.evaluation_histogram_fact")
+        hist_fact_post = spark.read.table("spark_catalog.gold.evaluation_histogram_fact")
 
-    rpm_c1_sum_post = _rpm_sum(hist_fact_post, 1)
-    rpm_c2_sum_post = _rpm_sum(hist_fact_post, 2)
-    speed_c2_rows_post = (
-        hist_fact_post.where((F.col("visual_id") == speed_vid) & (F.col("container_id") == 2))
-        .orderBy("bin_id")
-        .collect()
-    )
+        rpm_c1_sum_post = _rpm_sum(hist_fact_post, 1)
+        rpm_c2_sum_post = _rpm_sum(hist_fact_post, 2)
+        speed_c2_rows_post = (
+            hist_fact_post.where((F.col("visual_id") == speed_vid) & (F.col("container_id") == 2))
+            .orderBy("bin_id")
+            .collect()
+        )
 
-    # rpm_hist_p1 was recomputed over ALL containers using the shrunk channels:
-    # container 2's shrunk data yields a smaller (but still positive) total duration.
-    assert rpm_c2_sum_post > 0
-    assert rpm_c2_sum_post < rpm_c2_sum_pre, (
-        "Forced full recalc must recompute rpm_hist_p1 for container 2 (unmodified "
-        "timestamp) against the shrunk silver data"
-    )
-    # container 1's data is unchanged, so its recomputed values match.
-    assert rpm_c1_sum_post == rpm_c1_sum_pre
+        # rpm_hist_p1 was recomputed over ALL containers using the shrunk channels:
+        # container 2's shrunk data yields a smaller (but still positive) total duration.
+        assert rpm_c2_sum_post > 0
+        assert rpm_c2_sum_post < rpm_c2_sum_pre, (
+            "Forced full recalc must recompute rpm_hist_p1 for container 2 (unmodified "
+            "timestamp) against the shrunk silver data"
+        )
+        # container 1's data is unchanged, so its recomputed values match.
+        assert rpm_c1_sum_post == rpm_c1_sum_pre
 
-    # speed_hist_p1 is neither listed nor on an updated container -> its gold rows
-    # are preserved untouched, even though it shares the histogram_fact table.
-    assert speed_c2_rows_post == speed_c2_rows_pre
+        # speed_hist_p1 is neither listed nor on an updated container -> its gold rows
+        # are preserved untouched, even though it shares the histogram_fact table.
+        assert speed_c2_rows_post == speed_c2_rows_pre
+    finally:
+        spark.sql(f"DROP TABLE IF EXISTS {cm_scratch}")
+        spark.sql(f"DROP TABLE IF EXISTS {ch_scratch}")
 
 
 def add_aggs_to_report(my_report):

--- a/tests/impulse_reporting/unit/config/config_parser_test.py
+++ b/tests/impulse_reporting/unit/config/config_parser_test.py
@@ -7,6 +7,7 @@ from impulse_reporting.config.config_parser import (
     Comparator,
     ContainerFilters,
     DataType,
+    FullRecalculation,
     IncrementalConfig,
     ImpulseConfig,
     MetricFilter,
@@ -74,6 +75,37 @@ def test_impulse_config_from_dict():
         "start_ts",
         "stop_ts",
     ]
+
+
+def test_impulse_config_full_recalculation_defaults_to_none():
+    """full_recalculation is optional and absent by default."""
+    config = ImpulseConfig.model_validate(impulse_config_JSON)
+    assert config.full_recalculation is None
+
+
+def test_impulse_config_full_recalculation_parsed():
+    """full_recalculation parses into a FullRecalculation with per-kind name lists."""
+    config_json = impulse_config_JSON.copy()
+    config_json["full_recalculation"] = {
+        "aggregations": ["Temperature Histogram"],
+        "events": ["Overspeed"],
+        "calculated_channels": ["Power"],
+    }
+    config = ImpulseConfig.model_validate(config_json)
+    assert isinstance(config.full_recalculation, FullRecalculation)
+    assert config.full_recalculation.aggregations == ["Temperature Histogram"]
+    assert config.full_recalculation.events == ["Overspeed"]
+    assert config.full_recalculation.calculated_channels == ["Power"]
+
+
+def test_impulse_config_full_recalculation_partial_kinds_default_empty():
+    """Kinds omitted from full_recalculation default to empty lists."""
+    config_json = impulse_config_JSON.copy()
+    config_json["full_recalculation"] = {"aggregations": ["A"]}
+    config = ImpulseConfig.model_validate(config_json)
+    assert config.full_recalculation.aggregations == ["A"]
+    assert config.full_recalculation.events == []
+    assert config.full_recalculation.calculated_channels == []
 
 
 def test_impulse_config_data_format_defaults_to_rle():

--- a/tests/impulse_reporting/unit/core/report_test.py
+++ b/tests/impulse_reporting/unit/core/report_test.py
@@ -567,3 +567,64 @@ class TestValidateAggregationEvents:
         report.add_page(page)
 
         report._validate_aggregation_events()
+
+
+class TestValidateFullRecalculationScope:
+    """Tests for _validate_full_recalculation_scope method."""
+
+    @staticmethod
+    def _report_with_scope(scope: dict) -> Report:
+        report: Report = Report(
+            name="my_report",
+            spark=None,
+            workspace_client=create_autospec(WorkspaceClient),
+            config=dict(DUMMY_CONFIG, full_recalculation=scope),
+        )
+        ts_expr = TimeSeriesSelector(TagSelector("name") == "test_signal")
+        event = BasicEvent(name="my_event", expr=ts_expr > 0)
+        report.add_event(event)
+
+        stats = StatsAggregator(
+            name="my_agg",
+            input_expressions=[ts_expr],
+            channel_names=["test_signal"],
+            statistics=["min", "max"],
+            event=event,
+        )
+        page = Page(page_number=1)
+        page.add_aggregation(stats)
+        report.add_page(page)
+        return report
+
+    def test_no_full_recalculation_config_passes(self):
+        report: Report = Report(
+            name="my_report",
+            spark=None,
+            workspace_client=create_autospec(WorkspaceClient),
+            config=DUMMY_CONFIG,
+        )
+        # No full_recalculation configured → nothing to validate.
+        report._validate_full_recalculation_scope()
+
+    def test_all_known_names_pass(self):
+        report = self._report_with_scope({"aggregations": ["my_agg"], "events": ["my_event"]})
+        report._validate_full_recalculation_scope()
+
+    def test_unknown_aggregation_name_raises(self):
+        report = self._report_with_scope({"aggregations": ["nope_agg"]})
+        with pytest.raises(ValueError) as exc_info:
+            report._validate_full_recalculation_scope()
+        assert "nope_agg" in str(exc_info.value)
+        # Error lists the valid registered names.
+        assert "my_agg" in str(exc_info.value)
+
+    def test_unknown_event_name_raises(self):
+        report = self._report_with_scope({"events": ["nope_event"]})
+        with pytest.raises(ValueError) as exc_info:
+            report._validate_full_recalculation_scope()
+        assert "nope_event" in str(exc_info.value)
+        assert "my_event" in str(exc_info.value)
+
+    def test_empty_scope_lists_pass(self):
+        report = self._report_with_scope({})
+        report._validate_full_recalculation_scope()

--- a/tests/impulse_reporting/unit/core/report_utils_test.py
+++ b/tests/impulse_reporting/unit/core/report_utils_test.py
@@ -367,6 +367,81 @@ class TestSplitByHashChange:
                 kind="bogus",
             )
 
+    def test_force_recalc_promotes_unchanged_item_to_changed(self):
+        """A hash-unchanged item named in force_recalc_names moves to changed."""
+        forced, kept = MagicMock(), MagicMock()
+        forced.get_id.return_value = 7
+        forced.get_name.return_value = "Force Me"
+        kept.get_id.return_value = 8
+        kept.get_name.return_value = "Leave Me"
+
+        mock_sink = MagicMock()
+        mock_sink.config.get_output_uri_dimension_table.return_value = "catalog.gold.dim"
+
+        mock_comparator = MagicMock()
+        # Both start out unchanged by hash.
+        mock_comparator.group_aggregations_by_hash_change.return_value = ([], [forced, kept])
+
+        changed, unchanged, changed_ids = split_by_hash_change(
+            items_by_type={"HISTOGRAM": [forced, kept]},
+            type_enum=MagicMock(),
+            sink=mock_sink,
+            spark=MagicMock(),
+            hash_comparator=mock_comparator,
+            kind="aggregation",
+            force_recalc_names={"Force Me"},
+        )
+
+        assert changed == {"HISTOGRAM": [forced]}
+        assert unchanged == {"HISTOGRAM": [kept]}
+        assert changed_ids == {"HISTOGRAM": [7]}
+
+    def test_force_recalc_name_not_present_is_noop(self):
+        """A forced name matching no unchanged item leaves the split untouched."""
+        item = MagicMock()
+        item.get_id.return_value = 5
+        item.get_name.return_value = "Real Name"
+
+        mock_sink = MagicMock()
+        mock_sink.config.get_output_uri_dimension_table.return_value = "catalog.gold.dim"
+
+        mock_comparator = MagicMock()
+        mock_comparator.group_events_by_hash_change.return_value = ([], [item])
+
+        changed, unchanged, changed_ids = split_by_hash_change(
+            items_by_type={"BASIC_EVENT": [item]},
+            type_enum=MagicMock(),
+            sink=mock_sink,
+            spark=MagicMock(),
+            hash_comparator=mock_comparator,
+            kind="event",
+            force_recalc_names={"Some Typo"},
+        )
+
+        assert changed == {}
+        assert unchanged == {"BASIC_EVENT": [item]}
+        assert changed_ids == {}
+
+    def test_force_recalc_ignored_in_sinkless_mode(self):
+        """Sinkless mode already treats everything as changed; the param is a no-op."""
+        item = MagicMock()
+        item.get_id.return_value = 1
+        item.get_name.return_value = "Anything"
+
+        changed, unchanged, changed_ids = split_by_hash_change(
+            items_by_type={"BASIC_EVENT": [item]},
+            type_enum=MagicMock(),
+            sink=None,
+            spark=MagicMock(),
+            hash_comparator=MagicMock(),
+            kind="event",
+            force_recalc_names={"Anything"},
+        )
+
+        assert changed == {"BASIC_EVENT": [item]}
+        assert unchanged == {}
+        assert changed_ids == {"BASIC_EVENT": [1]}
+
 
 # ============================================================================
 # Tests: dispatch_events


### PR DESCRIPTION
## Summary

**What**

Adds an optional `full_recalculation` config that names aggregations, events, and/or calculated channels to fully recompute on the next incremental run, regardless of whether their definition hash changed. Listed entities recompute over all containers and fully replace their gold rows, while everything else stays incremental.

**Why**

Previously there was no way to force a full recompute of a specific entity whose definition was unchanged (for example, to backfill after a persistence fix or corrected upstream data). The only options were a full-mode run (recomputes everything, expensive) or artificially changing the definition.

**How**

The feature hooks into the existing changed/unchanged grouping. `split_by_hash_change` gained a `force_recalc_names` argument that promotes hash-unchanged items into the "changed" bucket, reusing the entire existing changed-path machinery (all-container solve plus delete-by-source pruning). No persistence-layer changes were needed. It is a no-op in full mode, where everything already recomputes.

**Changes**

- `config/config_parser.py`: new `FullRecalculation` model and optional `full_recalculation` field on `ImpulseConfig`.
- `core/report_utils.py`: `force_recalc_names` param on `split_by_hash_change`, plus `full_recalc_names`, `registered_names_by_kind`, and `validate_full_recalculation_scope` helpers.
- `core/report.py`: wires the config scope into the three grouping call sites and validates the scope at the start of `determine_report` (raises on names that match no registered entity).

**Tests**

- Unit: promotion/no-op behavior in `split_by_hash_change`, config parsing, and fail-fast validation on unknown names.
- Integration: an incremental run where a hash-unchanged aggregation is scoped for recalc is recomputed across all containers (verified on real values), while a non-listed unchanged aggregation sharing the same fact table is left untouched.

## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing completed
- [x] Documentation updated (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new linter warnings introduced
