### PR TITLE
Skip Delta version pinning for view inputs without logging an error

### DIFF
--- a/src/impulse_query_engine/measurement_db.py
+++ b/src/impulse_query_engine/measurement_db.py
@@ -109,32 +109,43 @@ class MeasurementDB:
     def query(self):
         return QueryBuilder(db=self)
 
-    @staticmethod
-    def _current_delta_version(spark, table_locations: str, uri: str) -> int:
-        """Resolve the latest committed Delta version of ``uri``.
+    def _current_delta_version(self, spark, uri: str) -> int | None:
+        """Latest committed Delta version of ``uri``, or ``None`` if unpinnable.
 
-        Handles UC (``catalog.schema.table``, resolved by ``forName`` with the
-        full name) and path modes. Read-only: if the reference cannot be
-        resolved (view, non-Delta, unknown table), the error propagates to
-        :meth:`pin_versions`, which skips pinning that table so it keeps reading
-        the latest version — never a wrong one.
+        Read-only and never raises. Views are detected via catalog metadata
+        (before any Delta command runs, so serverless logs no
+        ``[DELTA_MISSING_DELTA_TABLE]`` ERROR) and non-Delta / unresolvable
+        tables via the caught exception; both warn and return ``None`` so
+        :meth:`pin_versions` skips them and they keep reading the latest version.
         """
         from delta.tables import DeltaTable
 
-        if table_locations == "unity_catalog":
-            dt = DeltaTable.forName(spark, uri)
-        else:  # path mode
-            dt = DeltaTable.forPath(spark, uri)
-        return int(dt.history(1).select("version").first()[0])
+        try:
+            if self.config.table_locations == "unity_catalog":
+                if spark.catalog.getTable(uri).tableType == "VIEW":
+                    warnings.warn(
+                        f"'{uri}' is a view, not a Delta table; reading the latest "
+                        f"version (a view has no Delta history to pin a snapshot to).",
+                        stacklevel=2,
+                    )
+                    return None
+                dt = DeltaTable.forName(spark, uri)
+            else:  # path mode
+                dt = DeltaTable.forPath(spark, uri)
+            return int(dt.history(1).select("version").first()[0])
+        except Exception as exc:  # noqa: BLE001 - graceful degradation per table
+            warnings.warn(f"Could not pin Delta version for '{uri}': {exc}", stacklevel=2)
+            return None
 
     def pin_versions(self, spark) -> None:
         """Pin every configured silver table to its current Delta version.
 
         Resolves each table's latest version once so that all lazily-evaluated
         reads in a run observe the same snapshot regardless of when they
-        materialize (issue #87). Debug mode is exempt. Tables that cannot be
-        time-traveled (views, non-Delta, unresolvable) are skipped with a
-        warning and continue to read the latest version.
+        materialize (issue #87). Debug mode is exempt. Anything that cannot be
+        time-traveled is skipped, warns, and continues to read the latest
+        version: views (no Delta history) and non-Delta / unresolvable tables.
+        See :meth:`_current_delta_version`.
 
         **Opt-in for direct query-engine use.** This is *not* called
         automatically when you query a ``MeasurementDB`` directly — reads
@@ -153,10 +164,9 @@ class MeasurementDB:
             return
         pinned: dict[str, int] = {}
         for uri in self.config.configured_table_uris():
-            try:
-                pinned[uri] = self._current_delta_version(spark, self.config.table_locations, uri)
-            except Exception as exc:  # noqa: BLE001 - graceful degradation per table
-                warnings.warn(f"Could not pin Delta version for '{uri}': {exc}", stacklevel=2)
+            version = self._current_delta_version(spark, uri)
+            if version is not None:
+                pinned[uri] = version
         self.config.pinned_versions = pinned
 
     def _read_table(self, spark, table_name):

--- a/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
+++ b/tests/impulse_query_engine/unit/measurement_db_versioning_test.py
@@ -4,8 +4,9 @@
 ``pin_versions`` resolves each configured silver table's current Delta version
 once at run start; ``_read_table`` then reads with ``versionAsOf`` so every
 lazy op in the run observes the same snapshot even if the table changes
-mid-run. Debug mode is exempt; non-Delta / unresolvable tables are skipped
-with a warning and continue to read the latest version.
+mid-run. Debug mode is exempt. Views are detected via catalog metadata (so no
+Delta command hits them) and skipped with a warning; non-Delta / unresolvable
+tables are also skipped with a warning. Skipped tables read the latest version.
 """
 
 from unittest.mock import create_autospec
@@ -94,3 +95,25 @@ def test_pin_versions_skips_non_delta_and_warns(spark):  # noqa: F811
         db.pin_versions(spark)
     # Unresolvable table is skipped, leaving the pin map empty (reads latest).
     assert cfg.pinned_versions == {}
+
+
+def test_pin_versions_skips_view_and_warns(spark, pin_schema):  # noqa: F811
+    # A view has no Delta history and cannot be time-traveled. It must be
+    # detected via catalog metadata (tableType == "VIEW") and skipped WITHOUT
+    # running a Delta history op against it -- that op is what makes serverless
+    # compute log an [DELTA_MISSING_DELTA_TABLE] ERROR. The skip emits a plain
+    # warning naming the view, not that internal error.
+    table = f"{pin_schema}.container_metrics_base"
+    view = f"{pin_schema}.container_metrics_view"
+    spark.range(4).toDF("container_id").write.format("delta").mode("overwrite").saveAsTable(table)
+    spark.sql(f"CREATE VIEW {view} AS SELECT * FROM {table}")
+
+    cfg = MeasurementDBConfig(container_metrics_table=view, table_locations="unity_catalog")
+    db = _db(cfg)
+    with pytest.warns(UserWarning, match="is a view"):
+        db.pin_versions(spark)
+
+    # The view is skipped: nothing pinned, and the read returns the view's rows
+    # at the latest version.
+    assert cfg.pinned_versions == {}
+    assert db.container_metrics(spark).count() == 4


### PR DESCRIPTION
## Summary

When a report is configured with a Unity Catalog view as a silver input, `pin_versions` tried to read the view's Delta history to pin a snapshot. Views have no Delta history, so on serverless compute this surfaced a noisy `[DELTA_MISSING_DELTA_TABLE]` ERROR before the exception was caught. The run still succeeded, but the error was alarming.

## Changes

- `_current_delta_version` now detects views up front via catalog metadata (`tableType == "VIEW"`) before issuing any Delta command, so no history op ever hits a view and serverless logs no error.
- Views are skipped with a plain warning and read the latest version. Materialized views and streaming tables are Delta-backed and still pin normally.
- The per-table try/except and unpinnable-returns-`None` logic now live in `_current_delta_version`, simplifying `pin_versions` to a loop.
- Added a test covering the view case.

## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing completed
- [ ] Documentation updated (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new linter warnings introduced
