### PR TITLE
Cap containers per incremental report run with max_containers_per_run

### DIFF
--- a/src/impulse_reporting/config/config_parser.py
+++ b/src/impulse_reporting/config/config_parser.py
@@ -404,7 +404,7 @@ class QueryEngine(BaseModel):
     @field_validator("max_containers_per_run", mode="after")
     @classmethod
     def _validate_max_containers_per_run(cls, value: int | None) -> int | None:
-        """Cap on containers per incremental run; ``None`` disables it (see issue #88)."""
+        """Cap on containers per incremental run; ``None`` disables it."""
         if value is not None and value < 1:
             raise ValueError(
                 "max_containers_per_run must be >= 1 when set (None disables the cap)."

--- a/src/impulse_reporting/config/config_parser.py
+++ b/src/impulse_reporting/config/config_parser.py
@@ -399,6 +399,17 @@ class QueryEngine(BaseModel):
     raw_encoder: RawEncoder | None = None
     solver_config: SolverConfig | None = None
     batch_size: int = 500
+    max_containers_per_run: int | None = None
+
+    @field_validator("max_containers_per_run", mode="after")
+    @classmethod
+    def _validate_max_containers_per_run(cls, value: int | None) -> int | None:
+        """Cap on containers per incremental run; ``None`` disables it (see issue #88)."""
+        if value is not None and value < 1:
+            raise ValueError(
+                "max_containers_per_run must be >= 1 when set (None disables the cap)."
+            )
+        return value
 
     @model_validator(mode="after")
     def validate_drop_implausible_data_requires_raw(self):

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -944,25 +944,36 @@ class Report:
         persist_results: bool = True,
         cleanup_temp_tables: bool | None = None,
     ):
-        """Determine and (optionally) persist a report in one call.
+        """Determine and persist a report, draining all container batches.
 
-        Convenience wrapper over :meth:`determine_report` + :meth:`persist_results`
-        (both remain usable standalone). With ``max_containers_per_run`` set, each
-        incremental ``run()`` commits at most that many containers; call it repeatedly
-        to advance through the population (issue #88).
+        Wraps :meth:`determine_report` + :meth:`persist_results` (both remain usable
+        standalone). With ``max_containers_per_run`` set on an incremental run, ``run()``
+        loops: each iteration commits at most that many upserted containers, and the loop
+        continues until a run observes at most that many remaining (the last batch clears
+        the rest). After the first iteration all definition hashes are current, so later
+        iterations recompute only unchanged entities over the next batch of new containers.
+        Without a cap (or in full mode) it is a single determine+persist pass.
 
         Parameters
         ----------
         is_incremental : bool, optional
             Forwarded to :meth:`determine_report` (config still overrides it).
         persist_results : bool, optional
-            When True (default), persist after determining; False runs determine only.
+            When True (default), persist after determining and drain the batches. When
+            False, run :meth:`determine_report` once without persisting (no iteration —
+            nothing commits, so the batch cannot advance).
         cleanup_temp_tables : bool | None, optional
             Forwarded to :meth:`persist_results`.
         """
-        self.determine_report(is_incremental)
-        if persist_results:
+        while True:
+            self.determine_report(is_incremental)
+            if not persist_results:
+                return
             self.persist_results(cleanup_temp_tables)
+            # Stop once a run processed the remainder (uncapped upserted <= cap); also
+            # covers no cap / full mode, where the flag stays False.
+            if not self._more_batches_pending:
+                return
 
     @telemetry_logger("report", "determine_report")
     def determine_report(self, is_incremental: bool = None):
@@ -1012,15 +1023,22 @@ class Report:
         self._is_incremental = self._resolve_is_incremental(is_incremental)
 
         # Detect containers to process (incremental mode only): new + updated.
+        # ``_more_batches_pending`` tells run()'s batch loop whether more than one batch
+        # of upserted containers remains; reset each call so it never carries stale state.
         pre_filtered_containers_df = None
+        self._more_batches_pending = False
         if self._is_incremental:
             pre_filtered_containers_df = self._detect_upserted_containers()
-            # Cap containers per run (issue #88): committed containers get a fresh
+            # Cap containers per run: committed containers get a fresh
             # measurement_dimension timestamp and drop out of the next run's detection,
             # so successive runs advance through the population. Order by container_id
             # for deterministic batches and forward progress.
             max_containers = self.config.query_engine.max_containers_per_run
             if max_containers is not None and pre_filtered_containers_df is not None:
+                # Probe with limit(N+1).count() (bounded) before capping.
+                self._more_batches_pending = (
+                    pre_filtered_containers_df.limit(max_containers + 1).count() > max_containers
+                )
                 pre_filtered_containers_df = pre_filtered_containers_df.orderBy(
                     "container_id"
                 ).limit(max_containers)
@@ -1044,7 +1062,7 @@ class Report:
         # Container scope for CHANGED entities: without a cap, None (all containers).
         # Under a cap, all historical (gold) containers plus the capped new ones, so a
         # definition change is re-applied to existing containers while new containers
-        # beyond the cap are deferred (issue #88).
+        # beyond the cap are deferred.
         changed_pre_filtered_containers_df = self._changed_scope(pre_filtered_containers_df)
 
         hash_comparator = DefinitionHashComparator(self.spark)
@@ -1363,7 +1381,7 @@ class Report:
         return _detector.updated_within(containers_df, measurement_dim_table)
 
     def _changed_scope(self, capped_upserted_df: DataFrame | None) -> DataFrame | None:
-        """Container scope for CHANGED entities under a cap (issue #88).
+        """Container scope for CHANGED entities under a cap.
 
         All historical (gold) containers plus the capped upserted set, so a definition
         change is re-applied to existing containers while new containers beyond the cap

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -935,6 +935,33 @@ class Report:
             pre_filtered_containers_df=pre_filtered_containers_df,
         )
 
+    @telemetry_logger("report", "run")
+    def run(
+        self,
+        is_incremental: bool = None,
+        persist_results: bool = True,
+        cleanup_temp_tables: bool | None = None,
+    ):
+        """Determine and (optionally) persist a report in one call.
+
+        Convenience wrapper over :meth:`determine_report` + :meth:`persist_results`
+        (both remain usable standalone). With ``max_containers_per_run`` set, each
+        incremental ``run()`` commits at most that many containers; call it repeatedly
+        to advance through the population (issue #88).
+
+        Parameters
+        ----------
+        is_incremental : bool, optional
+            Forwarded to :meth:`determine_report` (config still overrides it).
+        persist_results : bool, optional
+            When True (default), persist after determining; False runs determine only.
+        cleanup_temp_tables : bool | None, optional
+            Forwarded to :meth:`persist_results`.
+        """
+        self.determine_report(is_incremental)
+        if persist_results:
+            self.persist_results(cleanup_temp_tables)
+
     @telemetry_logger("report", "determine_report")
     def determine_report(self, is_incremental: bool = None):
         """
@@ -986,18 +1013,30 @@ class Report:
         pre_filtered_containers_df = None
         if self._is_incremental:
             pre_filtered_containers_df = self._detect_upserted_containers()
+            # Cap containers per run (issue #88): committed containers get a fresh
+            # measurement_dimension timestamp and drop out of the next run's detection,
+            # so successive runs advance through the population. Order by container_id
+            # for deterministic batches and forward progress.
+            max_containers = self.config.query_engine.max_containers_per_run
+            if max_containers is not None and pre_filtered_containers_df is not None:
+                pre_filtered_containers_df = pre_filtered_containers_df.orderBy(
+                    "container_id"
+                ).limit(max_containers)
 
         # Two signals for persistence:
         # - has_processed_containers (new + updated): gates whether a fact table is
         #   written (new containers must be inserted). Only a bool is needed, so
         #   probe emptiness with isEmpty() rather than collecting the whole id list.
-        # - updated container ids: scopes the delete-by-source, since only
-        #   containers that already have gold rows can have stale rows to prune.
+        # - updated container ids: scopes the delete-by-source; derived from the
+        #   (capped) upserted set (see _updated_containers_within), so a capped run
+        #   never prunes containers it did not reprocess.
         self._has_processed_containers = (
             pre_filtered_containers_df is not None and not pre_filtered_containers_df.isEmpty()
         )
         self._updated_container_ids = self._collect_container_ids(
-            self._detect_updated_containers() if self._is_incremental else None
+            self._updated_containers_within(pre_filtered_containers_df)
+            if self._is_incremental
+            else None
         )
 
         hash_comparator = DefinitionHashComparator(self.spark)
@@ -1298,29 +1337,19 @@ class Report:
             gold_last_modified_col=gold_col,
         )
 
-    def _detect_updated_containers(self) -> DataFrame | None:
-        """Detect only UPDATED containers (present in gold, newer silver timestamp).
+    def _updated_containers_within(self, containers_df: DataFrame | None) -> DataFrame | None:
+        """Updated containers within the run's (capped) upserted set, for delete scoping.
 
-        Excludes new containers — see
-        ``ContainerUpsertDetector.detect_updated_containers``. Used to scope the
-        incremental delete-by-source. Returns None in sinkless mode or when the
-        gold table doesn't exist.
-
-        Returns
-        -------
-        DataFrame | None
-            Updated containers, or None.
+        Delegates to ``ContainerUpsertDetector.updated_within``. Returns None in
+        sinkless mode or when ``containers_df`` is None.
         """
+        if containers_df is None:
+            return None
         args = self._container_detection_args()
         if args is None:
             return None
-        detector, silver_containers, measurement_dim_table, silver_col, gold_col = args
-        return detector.detect_updated_containers(
-            silver_containers,
-            measurement_dim_table,
-            silver_last_modified_col=silver_col,
-            gold_last_modified_col=gold_col,
-        )
+        _detector, _silver_containers, measurement_dim_table, _silver_col, _gold_col = args
+        return _detector.updated_within(containers_df, measurement_dim_table)
 
     def _container_detection_args(self):
         """Shared inputs for container detection, or None in sinkless mode.

--- a/src/impulse_reporting/core/report.py
+++ b/src/impulse_reporting/core/report.py
@@ -911,6 +911,7 @@ class Report:
             catalog=getattr(self.config, "unity_sink", None) and self.config.unity_sink.catalog,
             schema=getattr(self.config, "unity_sink", None) and self.config.unity_sink.schema,
             pre_filtered_containers_df=pre_filtered_containers_df,
+            max_containers_per_run=self.config.query_engine.max_containers_per_run,
         )
 
     def _solve_calculated_channels_batched(
@@ -933,6 +934,7 @@ class Report:
             catalog=getattr(self.config, "unity_sink", None) and self.config.unity_sink.catalog,
             schema=getattr(self.config, "unity_sink", None) and self.config.unity_sink.schema,
             pre_filtered_containers_df=pre_filtered_containers_df,
+            max_containers_per_run=self.config.query_engine.max_containers_per_run,
         )
 
     @telemetry_logger("report", "run")
@@ -1039,6 +1041,12 @@ class Report:
             else None
         )
 
+        # Container scope for CHANGED entities: without a cap, None (all containers).
+        # Under a cap, all historical (gold) containers plus the capped new ones, so a
+        # definition change is re-applied to existing containers while new containers
+        # beyond the cap are deferred (issue #88).
+        changed_pre_filtered_containers_df = self._changed_scope(pre_filtered_containers_df)
+
         hash_comparator = DefinitionHashComparator(self.spark)
 
         # Group events and aggregations by type
@@ -1079,7 +1087,8 @@ class Report:
 
         # Centralized solve
         changed_solved_df = self._solve_expressions_batched(
-            all_changed_expressions, pre_filtered_containers_df=None
+            all_changed_expressions,
+            pre_filtered_containers_df=changed_pre_filtered_containers_df,
         )
         unchanged_solved_df = self._solve_expressions_batched(
             all_unchanged_expressions, pre_filtered_containers_df=pre_filtered_containers_df
@@ -1093,7 +1102,7 @@ class Report:
             changed_solved_df,
             self.query,
             self.solver,
-            None,
+            changed_pre_filtered_containers_df,
             ContainerEvent,
         )
         unchanged_event_dfs = dispatch_events(
@@ -1134,8 +1143,9 @@ class Report:
 
         # Calculated channels: own narrow batched solve driven here (mirrors the
         # wide expression solve above), producing a narrow ``solved_df`` that each
-        # channel type then shapes. Changed definitions recompute over all
-        # containers; unchanged ones over the incrementally-detected subset.
+        # channel type then shapes. Changed definitions recompute over the changed
+        # scope (all containers, or gold+capped under a cap); unchanged ones over the
+        # incrementally-detected subset.
         self._validate_unique_calculated_channels()
         channels_by_type = group_selectables_by_type(self.calculated_channels, ChannelType)
         changed_channels_by_type, unchanged_channels_by_type, self._changed_channel_ids = (
@@ -1158,7 +1168,7 @@ class Report:
             c.expression for cs in unchanged_channels_by_type.values() for c in cs
         ]
         changed_channel_solved_df = self._solve_calculated_channels_batched(
-            changed_channel_exprs, pre_filtered_containers_df=None
+            changed_channel_exprs, pre_filtered_containers_df=changed_pre_filtered_containers_df
         )
         unchanged_channel_solved_df = self._solve_calculated_channels_batched(
             unchanged_channel_exprs, pre_filtered_containers_df=pre_filtered_containers_df
@@ -1223,9 +1233,9 @@ class Report:
         )
 
         # Determine channel mapping resolution dimension.
-        # Mirror the fact split: aliases from changed definitions resolve
-        # over all containers, aliases only in unchanged definitions stay
-        # scoped to the incrementally-detected containers.
+        # Mirror the fact split: aliases from changed definitions resolve over the
+        # changed scope (all containers, or gold+capped under a cap), aliases only in
+        # unchanged definitions stay scoped to the incrementally-detected containers.
         changed_aliased_selectors = TimeSeriesExpression.collect_selectors(
             all_changed_expressions,
             uses_alias=True,
@@ -1242,6 +1252,7 @@ class Report:
                 changed_aliased_selectors=changed_aliased_selectors,
                 unchanged_aliased_selectors=unchanged_aliased_selectors,
                 pre_filtered_containers_df=pre_filtered_containers_df,
+                changed_pre_filtered_containers_df=changed_pre_filtered_containers_df,
             )
         )
 
@@ -1350,6 +1361,25 @@ class Report:
             return None
         _detector, _silver_containers, measurement_dim_table, _silver_col, _gold_col = args
         return _detector.updated_within(containers_df, measurement_dim_table)
+
+    def _changed_scope(self, capped_upserted_df: DataFrame | None) -> DataFrame | None:
+        """Container scope for CHANGED entities under a cap (issue #88).
+
+        All historical (gold) containers plus the capped upserted set, so a definition
+        change is re-applied to existing containers while new containers beyond the cap
+        are deferred (they have no gold rows, so the global changed-entity delete cannot
+        orphan them). Returns None (all containers, today's behavior) when no cap is set
+        or the run is not incremental.
+        """
+        if self.config.query_engine.max_containers_per_run is None or capped_upserted_df is None:
+            return None
+        args = self._container_detection_args()
+        if args is None:
+            return None
+        _detector, silver_containers, measurement_dim_table, _silver_col, _gold_col = args
+        gold_ids = self.spark.read.table(measurement_dim_table).select("container_id")
+        allowed = gold_ids.unionByName(capped_upserted_df.select("container_id")).distinct()
+        return silver_containers.join(allowed, on="container_id", how="inner")
 
     def _container_detection_args(self):
         """Shared inputs for container detection, or None in sinkless mode.

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -591,7 +591,7 @@ def solve_expressions_batched(
     pre_filtered_containers_df : DataFrame, optional
         Pre-filtered containers for incremental processing.
     max_containers_per_run : int, optional
-        Max containers per solve chunk (issue #88); ``None`` disables container chunking.
+        Max containers per solve chunk; ``None`` disables container chunking.
 
     Returns
     -------
@@ -669,7 +669,7 @@ def solve_calculated_channels_batched(
     ``max_containers_per_run`` chunks the effective container set (the
     ``pre_filtered_containers_df`` if given, else the full ``container_metrics``) into
     chunks of at most that many containers, combining chunks with ``unionByName`` too; the
-    result content is identical to an unchunked solve (issue #88). ``None`` disables it.
+    result content is identical to an unchunked solve. ``None`` disables it.
 
     Parameters
     ----------
@@ -693,7 +693,7 @@ def solve_calculated_channels_batched(
     pre_filtered_containers_df : DataFrame, optional
         Pre-filtered containers for incremental processing.
     max_containers_per_run : int, optional
-        Max containers per solve chunk (issue #88); ``None`` disables container chunking.
+        Max containers per solve chunk; ``None`` disables container chunking.
 
     Returns
     -------

--- a/src/impulse_reporting/core/report_utils.py
+++ b/src/impulse_reporting/core/report_utils.py
@@ -11,7 +11,7 @@ from functools import reduce
 from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as F
-from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import DataFrame, SparkSession, Window
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -499,6 +499,50 @@ def dispatch_calculated_channel_metrics(
     return metrics_dfs
 
 
+def _materialize_temp(df: DataFrame, run_id: str, idx, has_sink: bool, catalog, schema) -> str:
+    """Persist an intermediate ``df`` as a ``__impulse_temp_*`` Delta table (or temp view).
+
+    Returns the name to ``spark.table(...)`` it back with. Delta when a sink is
+    configured, a Spark temp view otherwise; the shared ``__impulse_temp_`` prefix means
+    :func:`cleanup_temp_tables` covers both.
+    """
+    name = f"__impulse_temp_{run_id}_{idx}"
+    if has_sink:
+        fq_name = f"`{catalog}`.`{schema}`.`{name}`"
+        df.write.format("delta").mode("overwrite").saveAsTable(fq_name)
+        return fq_name
+    df.createOrReplaceTempView(name)
+    return name
+
+
+def _container_chunks(spark, effective_df, max_n, has_sink, catalog, schema, cid_col):
+    """Yield ``effective_df`` sliced into chunks of at most ``max_n`` containers.
+
+    Numbers the distinct container ids by ``floor(row_number()/max_n)`` over an ordered
+    window and materializes that mapping once (no ``cache()``; sort once) so chunk
+    membership is deterministic and reproducible across runs. Each chunk is
+    ``effective_df`` inner-joined to its batch's ids — no ids are collected to the driver.
+    """
+    run_id = uuid.uuid4().hex[:8]
+    numbered = (
+        effective_df.select(cid_col)
+        .distinct()
+        .withColumn(
+            "_batch",
+            ((F.row_number().over(Window.orderBy(cid_col)) - F.lit(1)) / F.lit(max_n)).cast(
+                "long"
+            ),
+        )
+    )
+    name = _materialize_temp(numbered, run_id, "containers", has_sink, catalog, schema)
+    num_batches = spark.table(name).agg(F.max("_batch")).first()[0]
+    if num_batches is None:
+        return
+    for b in range(int(num_batches) + 1):
+        batch_ids = spark.table(name).where(F.col("_batch") == b).select(cid_col)
+        yield effective_df.join(batch_ids, on=cid_col, how="inner")
+
+
 def solve_expressions_batched(
     spark: SparkSession,
     expressions: list[TimeSeriesExpression],
@@ -510,14 +554,21 @@ def solve_expressions_batched(
     catalog: str = None,
     schema: str = None,
     pre_filtered_containers_df: DataFrame = None,
+    max_containers_per_run: int = None,
 ) -> DataFrame | None:
     """Solve all expressions in configurable batches and return a joined wide DataFrame.
 
-    Each batch is solved independently via ``query.select(*batch_exprs).solve(...)``.
-    When a sink is configured the intermediate result is persisted as a temporary
-    Delta table (``__impulse_temp_<run_id>_<batch_idx>``); otherwise a Spark temp view
-    is used.  After all batches are solved the per-batch DataFrames are joined on
-    ``container_id`` with a full outer join.
+    Each selector batch is solved via ``query.select(*batch_exprs).solve(...)``,
+    materialized to a temp Delta table/view, then joined on ``container_id`` with a full
+    outer join.
+
+    When ``max_containers_per_run`` is set, the effective container set (the
+    ``pre_filtered_containers_df`` if given, else the full ``container_metrics``) is also
+    sliced into chunks of at most that many containers; each chunk runs the selector
+    batching above and the chunks are ``unionByName``-combined (disjoint containers → row
+    append). This bounds per-chunk solve memory while returning the exact same content as
+    an unchunked solve. A set already ≤ the cap is a single chunk; an unset cap is the
+    original single-pass behavior.
 
     Parameters
     ----------
@@ -539,6 +590,8 @@ def solve_expressions_batched(
         Unity Catalog schema name (required when *has_sink* is ``True``).
     pre_filtered_containers_df : DataFrame, optional
         Pre-filtered containers for incremental processing.
+    max_containers_per_run : int, optional
+        Max containers per solve chunk (issue #88); ``None`` disables container chunking.
 
     Returns
     -------
@@ -549,36 +602,48 @@ def solve_expressions_batched(
     if not expressions:
         return None
 
-    run_id = uuid.uuid4().hex[:8]
-    batches = build_batches(expressions, batch_size)
-
-    batch_names: list[str] = []
-    for batch_idx, batch_exprs in enumerate(batches):
-        batch_query = query.select(*batch_exprs)
-        batch_df = batch_query.solve(
-            spark=spark,
-            solver=solver,
-            pre_filtered_containers_df=pre_filtered_containers_df,
-        )
-
-        if has_sink:
-            table_name = f"__impulse_temp_{run_id}_{batch_idx}"
-            fq_name = f"`{catalog}`.`{schema}`.`{table_name}`"
-            batch_df.write.format("delta").mode("overwrite").saveAsTable(fq_name)
-            batch_names.append(fq_name)
-        else:
-            view_name = f"__impulse_temp_{run_id}_{batch_idx}"
-            batch_df.createOrReplaceTempView(view_name)
-            batch_names.append(view_name)
-
     cid_col = solver.config.container_id_col
-    dfs = [spark.table(name) for name in batch_names]
 
-    result = dfs[0]
-    for i in range(1, len(dfs)):
-        result = result.join(dfs[i], on=cid_col, how="full_outer")
+    def _solve_selector_batches(pre_filter: DataFrame | None) -> DataFrame:
+        run_id = uuid.uuid4().hex[:8]
+        batch_names = [
+            _materialize_temp(
+                query.select(*batch_exprs).solve(
+                    spark=spark, solver=solver, pre_filtered_containers_df=pre_filter
+                ),
+                run_id,
+                batch_idx,
+                has_sink,
+                catalog,
+                schema,
+            )
+            for batch_idx, batch_exprs in enumerate(build_batches(expressions, batch_size))
+        ]
+        dfs = [spark.table(name) for name in batch_names]
+        result = dfs[0]
+        for df in dfs[1:]:
+            result = result.join(df, on=cid_col, how="full_outer")
+        return result
 
-    return result
+    if max_containers_per_run is None:
+        return _solve_selector_batches(pre_filtered_containers_df)
+
+    effective = (
+        pre_filtered_containers_df
+        if pre_filtered_containers_df is not None
+        else query.db.container_metrics(spark)
+    )
+    parts = [
+        _solve_selector_batches(chunk)
+        for chunk in _container_chunks(
+            spark, effective, max_containers_per_run, has_sink, catalog, schema, cid_col
+        )
+    ]
+    # No chunks => empty container set; fall back to a single solve so the result matches
+    # the non-chunked path (an empty-rows DataFrame, not None).
+    if not parts:
+        return _solve_selector_batches(pre_filtered_containers_df)
+    return reduce(lambda a, b: a.unionByName(b), parts)
 
 
 def solve_calculated_channels_batched(
@@ -592,21 +657,19 @@ def solve_calculated_channels_batched(
     catalog: str = None,
     schema: str = None,
     pre_filtered_containers_df: DataFrame = None,
+    max_containers_per_run: int = None,
 ) -> DataFrame | None:
     """Solve calculated channels in configurable batches; return the unioned rows.
 
-    The narrow, row-append counterpart to :func:`solve_expressions_batched`. Each
-    batch is solved independently via
-    ``query.select(*batch).solve_calculated_channels(...)`` and persisted as a
-    temporary Delta table (``__impulse_temp_<run_id>_<batch_idx>``) when a sink is
-    configured, or a Spark temp view otherwise — the same convention (and shared
-    ``__impulse_temp_*`` prefix, so :func:`cleanup_temp_tables` covers it).
+    Narrow, row-append counterpart to :func:`solve_expressions_batched`: each selector
+    batch is solved via ``query.select(*batch).solve_calculated_channels(...)``,
+    materialized to a temp Delta table/view, and batches are combined with
+    ``unionByName`` (narrow output — many rows per container, different ``channel_id``s).
 
-    Unlike ``solve_expressions_batched`` (wide, one row per container → batches
-    combined with a full-outer join on ``container_id``), calculated-channel output
-    is narrow (``container_id, channel_id, tstart, tend, value, identity``; many
-    rows per container, batches hold different ``channel_id``s), so batches are
-    combined with **``unionByName``** (row append).
+    ``max_containers_per_run`` chunks the effective container set (the
+    ``pre_filtered_containers_df`` if given, else the full ``container_metrics``) into
+    chunks of at most that many containers, combining chunks with ``unionByName`` too; the
+    result content is identical to an unchunked solve (issue #88). ``None`` disables it.
 
     Parameters
     ----------
@@ -629,6 +692,8 @@ def solve_calculated_channels_batched(
         Unity Catalog schema name (required when *has_sink* is ``True``).
     pre_filtered_containers_df : DataFrame, optional
         Pre-filtered containers for incremental processing.
+    max_containers_per_run : int, optional
+        Max containers per solve chunk (issue #88); ``None`` disables container chunking.
 
     Returns
     -------
@@ -639,32 +704,46 @@ def solve_calculated_channels_batched(
     if not qe_channels:
         return None
 
-    run_id = uuid.uuid4().hex[:8]
-    batches = build_batches(qe_channels, batch_size)
+    cid_col = solver.config.container_id_col
 
-    batch_names: list[str] = []
-    for batch_idx, batch_channels in enumerate(batches):
-        batch_df = query.select(*batch_channels).solve_calculated_channels(
-            spark, solver, pre_filtered_containers_df
+    def _solve_selector_batches(pre_filter: DataFrame | None) -> DataFrame:
+        run_id = uuid.uuid4().hex[:8]
+        batch_names = [
+            _materialize_temp(
+                query.select(*batch_channels).solve_calculated_channels(spark, solver, pre_filter),
+                run_id,
+                batch_idx,
+                has_sink,
+                catalog,
+                schema,
+            )
+            for batch_idx, batch_channels in enumerate(build_batches(qe_channels, batch_size))
+        ]
+        dfs = [spark.table(name) for name in batch_names]
+        result = dfs[0]
+        for df in dfs[1:]:
+            result = result.unionByName(df)
+        return result
+
+    if max_containers_per_run is None:
+        return _solve_selector_batches(pre_filtered_containers_df)
+
+    effective = (
+        pre_filtered_containers_df
+        if pre_filtered_containers_df is not None
+        else query.db.container_metrics(spark)
+    )
+    parts = [
+        _solve_selector_batches(chunk)
+        for chunk in _container_chunks(
+            spark, effective, max_containers_per_run, has_sink, catalog, schema, cid_col
         )
-
-        if has_sink:
-            table_name = f"__impulse_temp_{run_id}_{batch_idx}"
-            fq_name = f"`{catalog}`.`{schema}`.`{table_name}`"
-            batch_df.write.format("delta").mode("overwrite").saveAsTable(fq_name)
-            batch_names.append(fq_name)
-        else:
-            view_name = f"__impulse_temp_{run_id}_{batch_idx}"
-            batch_df.createOrReplaceTempView(view_name)
-            batch_names.append(view_name)
-
-    dfs = [spark.table(name) for name in batch_names]
-
-    result = dfs[0]
-    for df in dfs[1:]:
-        result = result.unionByName(df)
-
-    return result
+    ]
+    # No chunks => empty container set; fall back to a single solve so the result matches
+    # the non-chunked path (an empty-rows DataFrame, not None).
+    if not parts:
+        return _solve_selector_batches(pre_filtered_containers_df)
+    return reduce(lambda a, b: a.unionByName(b), parts)
 
 
 def cleanup_temp_tables(spark: SparkSession, catalog: str, schema: str) -> None:

--- a/src/impulse_reporting/incremental/container_detector.py
+++ b/src/impulse_reporting/incremental/container_detector.py
@@ -99,46 +99,40 @@ class ContainerUpsertDetector:
         upserted = new_containers.unionByName(updated_containers).dropDuplicates(["container_id"])
         return upserted
 
-    def detect_updated_containers(
+    def updated_within(
         self,
-        silver_containers_df: DataFrame,
+        candidate_containers_df: DataFrame,
         gold_measurement_dim_table: str,
-        silver_last_modified_col: str = "last_modified",
-        gold_last_modified_col: str = "last_modified",
-    ) -> DataFrame | None:
-        """Detect only UPDATED containers (present in gold with a newer silver timestamp).
+    ) -> DataFrame:
+        """Restrict upserted candidates to their UPDATED containers (issue #88).
 
-        Unlike :meth:`detect_upserted_containers`, this excludes NEW containers.
-        Only containers that already have gold rows can have *stale* rows, so this
-        is the correct set for scoping delete-by-source pruning.
+        The updated containers are those whose ``container_id`` already exists in the
+        gold ``measurement_dimension`` — new ones don't, and have no stale rows to
+        prune. Inner-joining candidates with gold both selects them and scopes them to
+        the candidates passed in, so a capped run's delete-by-source never touches
+        containers it did not reprocess. Candidates are already the upserted set, so
+        membership in gold is sufficient — no timestamp comparison needed.
 
         Parameters
         ----------
-        silver_containers_df : DataFrame
-            Container metrics from silver layer. Must contain ``container_id``.
+        candidate_containers_df : DataFrame
+            Upserted containers (silver schema, includes ``container_id``); e.g. the
+            capped ``pre_filtered_containers_df``.
         gold_measurement_dim_table : str
             URI of the gold measurement_dimension table.
-        silver_last_modified_col : str, optional
-            Silver freshness column, by default ``"last_modified"``.
-        gold_last_modified_col : str, optional
-            Gold freshness column, by default ``"last_modified"``.
 
         Returns
         -------
-        DataFrame | None
-            Updated containers (silver schema), or None if the gold table
-            doesn't exist.
+        DataFrame
+            Candidates already present in gold (silver schema); empty when gold absent.
         """
         if not self._table_exists(gold_measurement_dim_table):
-            return None
+            return candidate_containers_df.limit(0)
 
-        gold_df = self.spark.read.table(gold_measurement_dim_table)
-        return self._identify_updated_containers(
-            silver_containers_df,
-            gold_df,
-            silver_last_modified_col,
-            gold_last_modified_col,
+        gold_ids = (
+            self.spark.read.table(gold_measurement_dim_table).select("container_id").distinct()
         )
+        return candidate_containers_df.join(gold_ids, on="container_id", how="inner")
 
     def _identify_new_containers(self, silver_df: DataFrame, gold_df: DataFrame) -> DataFrame:
         """

--- a/src/impulse_reporting/incremental/container_detector.py
+++ b/src/impulse_reporting/incremental/container_detector.py
@@ -104,7 +104,7 @@ class ContainerUpsertDetector:
         candidate_containers_df: DataFrame,
         gold_measurement_dim_table: str,
     ) -> DataFrame:
-        """Restrict upserted candidates to their UPDATED containers (issue #88).
+        """Restrict upserted candidates to their UPDATED containers.
 
         The updated containers are those whose ``container_id`` already exists in the
         gold ``measurement_dimension`` — new ones don't, and have no stale rows to

--- a/src/impulse_reporting/meta/container_dimensions.py
+++ b/src/impulse_reporting/meta/container_dimensions.py
@@ -237,7 +237,7 @@ class ChannelMappingResolutionDimension:
         pre_filtered_containers_df : DataFrame, optional
             Pre-filtered containers for the unchanged (incremental) scope.
         changed_pre_filtered_containers_df : DataFrame, optional
-            Container scope for changed aliases (issue #88); None = all containers.
+            Container scope for changed aliases; None = all containers.
 
         Returns
         -------

--- a/src/impulse_reporting/meta/container_dimensions.py
+++ b/src/impulse_reporting/meta/container_dimensions.py
@@ -194,18 +194,19 @@ class ChannelMappingResolutionDimension:
         changed_aliased_selectors: list[TimeSeriesSelector],
         unchanged_aliased_selectors: list[TimeSeriesSelector],
         pre_filtered_containers_df: DataFrame = None,
+        changed_pre_filtered_containers_df: DataFrame = None,
     ) -> DataFrame | None:
         """
         Compute the channel mapping resolution dimension honoring the
         report's changed/unchanged definition split.
 
         Mirrors the scoping the fact pipeline uses: aliases referenced by
-        *changed* definitions are resolved over **all** containers
-        (``pre_filtered_containers_df=None``), while aliases referenced
-        only by *unchanged* definitions stay scoped to
-        ``pre_filtered_containers_df``. This keeps incremental runs cheap
-        without leaving older containers unresolved when a new alias is
-        introduced by a changed definition.
+        *changed* definitions are resolved over the changed scope
+        (``changed_pre_filtered_containers_df`` — all containers when None,
+        or gold+capped under a cap), while aliases referenced only by
+        *unchanged* definitions stay scoped to ``pre_filtered_containers_df``.
+        This keeps incremental runs cheap without leaving older containers
+        unresolved when a new alias is introduced by a changed definition.
 
         In full (non-incremental) mode ``pre_filtered_containers_df`` is
         ``None``, so both scopes resolve over all containers and the union
@@ -234,7 +235,9 @@ class ChannelMappingResolutionDimension:
             Aliased selectors from unchanged definitions (resolved over
             ``pre_filtered_containers_df``). May be empty.
         pre_filtered_containers_df : DataFrame, optional
-            Pre-filtered containers for incremental processing.
+            Pre-filtered containers for the unchanged (incremental) scope.
+        changed_pre_filtered_containers_df : DataFrame, optional
+            Container scope for changed aliases (issue #88); None = all containers.
 
         Returns
         -------
@@ -254,7 +257,7 @@ class ChannelMappingResolutionDimension:
             query=query,
             solver=solver,
             aliased_selectors=changed_aliased_selectors,
-            pre_filtered_containers_df=None,
+            pre_filtered_containers_df=changed_pre_filtered_containers_df,
         )
         unchanged_df = ChannelMappingResolutionDimension.get_dimension(
             spark=spark,

--- a/tests/impulse_reporting/integration/max_containers_per_run_test.py
+++ b/tests/impulse_reporting/integration/max_containers_per_run_test.py
@@ -1,4 +1,4 @@
-"""Integration tests for ``query_engine.max_containers_per_run`` (issue #88).
+"""Integration tests for ``query_engine.max_containers_per_run``.
 
 The cap bounds upserted containers per incremental run; committed containers drop out of
 the next run's detection, so repeated runs iterate the population and the final gold
@@ -43,8 +43,9 @@ def _config(silver_table, prefix, *, max_containers_per_run=None):
     )
 
 
-def _run(spark, silver_table, prefix, *, max_containers_per_run=None, add_aggs=add_aggs_to_report):
-    """Build a fresh report and run one determine+persist pass via ``run()``."""
+def _make_report(
+    spark, silver_table, prefix, *, max_containers_per_run=None, add_aggs=add_aggs_to_report
+):
     report = Report(
         name="cap_report",
         spark=spark,
@@ -52,7 +53,20 @@ def _run(spark, silver_table, prefix, *, max_containers_per_run=None, add_aggs=a
         config=dict(_config(silver_table, prefix, max_containers_per_run=max_containers_per_run)),
     )
     add_aggs(report)
-    report.run()  # determine_report() + persist_results()
+    return report
+
+
+def _run(spark, silver_table, prefix, *, max_containers_per_run=None, add_aggs=add_aggs_to_report):
+    """Run ONE determine+persist pass (single batch) — the granular API, no run() loop."""
+    report = _make_report(
+        spark,
+        silver_table,
+        prefix,
+        max_containers_per_run=max_containers_per_run,
+        add_aggs=add_aggs,
+    )
+    report.determine_report()
+    report.persist_results()
 
 
 def _container_ids(spark, prefix):
@@ -221,3 +235,54 @@ def test_changed_entity_capped_defers_beyond_cap_new_and_matches_uncapped(spark)
         assert _rows_without_meta(capped) == _rows_without_meta(
             uncapped
         ), f"{table}: capped changed-entity iteration must match the uncapped run"
+
+
+def test_run_drains_all_batches_in_one_call(spark):
+    """A single run() call loops determine+persist until the population is drained."""
+    # Seed gold with container 1.
+    _run(spark, "container_metrics_inc_1", "loop")
+    assert _container_ids(spark, "loop") == [1]
+
+    # New containers {2, 3}; cap=1. One run() call loops: {2} (more pending) then {3}.
+    _make_report(spark, "container_metrics", "loop", max_containers_per_run=1).run()
+    assert _container_ids(spark, "loop") == [1, 2, 3], "run() must drain every batch"
+
+    # Matches an uncapped single incremental run.
+    _run(spark, "container_metrics_inc_1", "loopbase")
+    _run(spark, "container_metrics", "loopbase")
+    for table in ("histogram_fact", "stats_aggregator_fact", "measurement_dimension"):
+        looped = spark.read.table(f"spark_catalog.gold.loop_{table}")
+        uncapped = spark.read.table(f"spark_catalog.gold.loopbase_{table}")
+        assert _rows_without_meta(looped) == _rows_without_meta(uncapped), table
+
+
+def test_run_loop_with_changed_definition(spark):
+    """run() drains batches when a definition changed: iter 1 recomputes, rest unchanged."""
+    _run(spark, "container_metrics_inc_1", "loopchg")  # D1 on container 1
+
+    # Changed definition (D2) + new {2,3}, cap=1, single run() call.
+    _make_report(
+        spark,
+        "container_metrics",
+        "loopchg",
+        max_containers_per_run=1,
+        add_aggs=add_aggs_to_report_changed_bins,
+    ).run()
+    assert _container_ids(spark, "loopchg") == [1, 2, 3]
+
+    # Uncapped D2 reference.
+    _run(spark, "container_metrics_inc_1", "loopchgbase")
+    _run(spark, "container_metrics", "loopchgbase", add_aggs=add_aggs_to_report_changed_bins)
+    for table in ("histogram_fact", "stats_aggregator_fact"):
+        looped = spark.read.table(f"spark_catalog.gold.loopchg_{table}")
+        uncapped = spark.read.table(f"spark_catalog.gold.loopchgbase_{table}")
+        assert _rows_without_meta(looped) == _rows_without_meta(uncapped), table
+
+
+def test_run_without_persist_does_not_loop(spark):
+    """run(persist_results=False) runs determine once and does not iterate."""
+    _run(spark, "container_metrics_inc_1", "nopersist")
+    report = _make_report(spark, "container_metrics", "nopersist", max_containers_per_run=1)
+    report.run(persist_results=False)
+    # Nothing was persisted beyond the seed, so gold still holds only container 1.
+    assert _container_ids(spark, "nopersist") == [1]

--- a/tests/impulse_reporting/integration/max_containers_per_run_test.py
+++ b/tests/impulse_reporting/integration/max_containers_per_run_test.py
@@ -1,0 +1,154 @@
+"""Integration tests for ``query_engine.max_containers_per_run`` (issue #88).
+
+The cap bounds upserted containers per incremental run; committed containers drop out of
+the next run's detection, so repeated runs iterate the population and the final gold
+matches an uncapped run. The cap needs gold to exist, so the tests seed gold with a
+subset first, then run capped passes over the full silver table (containers 1, 2, 3).
+"""
+
+from unittest.mock import create_autospec
+
+import pyspark.sql.functions as F
+from databricks.sdk import WorkspaceClient
+
+from impulse_reporting.config.config_parser import (
+    IncrementalConfig,
+    ImpulseConfig,
+    QueryEngine,
+    Source,
+    UnitySink,
+)
+from impulse_reporting.core.report import Report
+from tests.conftest import spark
+from tests.impulse_reporting.integration.incremental_report_test import add_aggs_to_report
+
+
+def _config(silver_table, prefix, *, max_containers_per_run=None):
+    return ImpulseConfig(
+        source=Source(
+            container_metrics_table=f"spark_catalog.silver.{silver_table}",
+            channel_metrics_table="spark_catalog.silver.channel_metrics",
+            channels_uri="spark_catalog.silver.channels",
+        ),
+        unity_sink=UnitySink(catalog="spark_catalog", schema="gold", table_prefix=prefix),
+        incremental=IncrementalConfig(
+            enabled=True,
+            silver_last_modified_column="timestamp",
+            gold_last_modified_column="_created_at",
+        ),
+        query_engine=QueryEngine(max_containers_per_run=max_containers_per_run),
+    )
+
+
+def _run(spark, silver_table, prefix, *, max_containers_per_run=None):
+    """Build a fresh report and run one determine+persist pass via ``run()``."""
+    report = Report(
+        name="cap_report",
+        spark=spark,
+        workspace_client=create_autospec(WorkspaceClient),
+        config=dict(_config(silver_table, prefix, max_containers_per_run=max_containers_per_run)),
+    )
+    add_aggs_to_report(report)
+    report.run()  # determine_report() + persist_results()
+
+
+def _container_ids(spark, prefix):
+    return sorted(
+        r.container_id
+        for r in spark.read.table(f"spark_catalog.gold.{prefix}_measurement_dimension").collect()
+    )
+
+
+def _rows_without_meta(df):
+    """Deterministic row set, dropping run-dependent columns.
+
+    Excludes ``_``-prefixed meta (e.g. ``_created_at``) and ``config_hash`` (a hash of
+    the full config, which intentionally differs between the capped/uncapped configs).
+    """
+    cols = [c for c in df.columns if not c.startswith("_") and c != "config_hash"]
+    return sorted(tuple(r) for r in df.select(*cols).collect())
+
+
+def test_max_containers_per_run_iterates_and_matches_uncapped(spark):
+    # --- Uncapped baseline (prefix "uncapped") ---------------------------------
+    # Seed gold with container 1 (initial full load), then one uncapped incremental
+    # run over the full silver table processes the remaining new containers {2, 3}.
+    _run(spark, "container_metrics_inc_1", "uncapped")
+    assert _container_ids(spark, "uncapped") == [1]
+    _run(spark, "container_metrics", "uncapped")  # cap=None
+    assert _container_ids(spark, "uncapped") == [1, 2, 3]
+
+    # --- Capped runs (prefix "capped", N=1) ------------------------------------
+    _run(spark, "container_metrics_inc_1", "capped")  # initial full load -> {1}
+    assert _container_ids(spark, "capped") == [1]
+
+    # First capped incremental run: {2, 3} are new; cap=1 processes the lowest (2).
+    _run(spark, "container_metrics", "capped", max_containers_per_run=1)
+    assert _container_ids(spark, "capped") == [1, 2], "cap must limit the run to one new container"
+
+    # Second capped run advances to container 3 (2 already committed, drops out).
+    _run(spark, "container_metrics", "capped", max_containers_per_run=1)
+    assert _container_ids(spark, "capped") == [1, 2, 3]
+
+    # Third capped run is a no-op: everything is already processed.
+    _run(spark, "container_metrics", "capped", max_containers_per_run=1)
+    assert _container_ids(spark, "capped") == [1, 2, 3]
+
+    # --- Gold from the capped iteration matches the uncapped run ----------------
+    for table in ("histogram_fact", "stats_aggregator_fact", "measurement_dimension"):
+        capped = spark.read.table(f"spark_catalog.gold.capped_{table}")
+        uncapped = spark.read.table(f"spark_catalog.gold.uncapped_{table}")
+        assert _rows_without_meta(capped) == _rows_without_meta(
+            uncapped
+        ), f"{table}: capped iteration must reproduce the uncapped gold"
+
+    # Real-value sanity check: the histogram carries positive accumulated duration.
+    total = (
+        spark.read.table("spark_catalog.gold.capped_histogram_fact")
+        .agg(F.sum("hist_value").alias("s"))
+        .collect()[0]["s"]
+    )
+    assert total is not None and total > 0
+
+
+def test_capped_run_does_not_prune_out_of_batch_updated_container(spark):
+    """A capped run must not prune gold rows for updated containers outside the cap."""
+    # Seed gold with containers 1 and 2 (initial full load).
+    _run(spark, "container_metrics_inc_1_2", "prune")
+    assert _container_ids(spark, "prune") == [1, 2]
+
+    hist_pre = spark.read.table("spark_catalog.gold.prune_histogram_fact")
+    container2_hist_pre = (
+        hist_pre.where(F.col("container_id") == 2).orderBy("visual_id", "bin_id").collect()
+    )
+    assert container2_hist_pre, "container 2 must have histogram rows after the initial load"
+    meas_pre = spark.read.table("spark_catalog.gold.prune_measurement_dimension")
+    container2_created_at_pre = (
+        meas_pre.where(F.col("container_id") == 2).select("_created_at").collect()[0][0]
+    )
+
+    # Mark BOTH containers as updated in silver (timestamp newer than gold _created_at).
+    modified = spark.read.table("spark_catalog.silver.container_metrics_inc_1_2").withColumn(
+        "timestamp", F.current_timestamp()
+    )
+    modified.write.format("delta").mode("overwrite").saveAsTable(
+        "spark_catalog.silver.container_metrics_prune_modified"
+    )
+
+    # Incremental run with cap=1: only container 1 (lowest id) is reprocessed;
+    # container 2 is updated but OUTSIDE the cap.
+    _run(spark, "container_metrics_prune_modified", "prune", max_containers_per_run=1)
+
+    assert _container_ids(spark, "prune") == [1, 2], "no container may be dropped"
+
+    hist_post = spark.read.table("spark_catalog.gold.prune_histogram_fact")
+    container2_hist_post = (
+        hist_post.where(F.col("container_id") == 2).orderBy("visual_id", "bin_id").collect()
+    )
+    # Container 2 was NOT in the cap -> its gold rows must be untouched (not pruned).
+    assert container2_hist_post == container2_hist_pre
+    meas_post = spark.read.table("spark_catalog.gold.prune_measurement_dimension")
+    container2_created_at_post = (
+        meas_post.where(F.col("container_id") == 2).select("_created_at").collect()[0][0]
+    )
+    assert container2_created_at_pre == container2_created_at_post, "container 2 must be untouched"

--- a/tests/impulse_reporting/integration/max_containers_per_run_test.py
+++ b/tests/impulse_reporting/integration/max_containers_per_run_test.py
@@ -20,7 +20,10 @@ from impulse_reporting.config.config_parser import (
 )
 from impulse_reporting.core.report import Report
 from tests.conftest import spark
-from tests.impulse_reporting.integration.incremental_report_test import add_aggs_to_report
+from tests.impulse_reporting.integration.incremental_report_test import (
+    add_aggs_to_report,
+    add_aggs_to_report_changed_bins,
+)
 
 
 def _config(silver_table, prefix, *, max_containers_per_run=None):
@@ -40,7 +43,7 @@ def _config(silver_table, prefix, *, max_containers_per_run=None):
     )
 
 
-def _run(spark, silver_table, prefix, *, max_containers_per_run=None):
+def _run(spark, silver_table, prefix, *, max_containers_per_run=None, add_aggs=add_aggs_to_report):
     """Build a fresh report and run one determine+persist pass via ``run()``."""
     report = Report(
         name="cap_report",
@@ -48,7 +51,7 @@ def _run(spark, silver_table, prefix, *, max_containers_per_run=None):
         workspace_client=create_autospec(WorkspaceClient),
         config=dict(_config(silver_table, prefix, max_containers_per_run=max_containers_per_run)),
     )
-    add_aggs_to_report(report)
+    add_aggs(report)
     report.run()  # determine_report() + persist_results()
 
 
@@ -152,3 +155,69 @@ def test_capped_run_does_not_prune_out_of_batch_updated_container(spark):
         meas_post.where(F.col("container_id") == 2).select("_created_at").collect()[0][0]
     )
     assert container2_created_at_pre == container2_created_at_post, "container 2 must be untouched"
+
+
+def _hist_container_ids(spark, prefix):
+    return {
+        r.container_id
+        for r in spark.read.table(f"spark_catalog.gold.{prefix}_histogram_fact")
+        .select("container_id")
+        .distinct()
+        .collect()
+    }
+
+
+def test_full_mode_container_chunked_solve_matches_uncapped(spark):
+    """Full-mode solve chunked by the cap (pre_filter=None) yields identical gold."""
+    # Full run over all 3 containers, uncapped vs cap=1 (solve chunked into 3 batches).
+    _run(spark, "container_metrics", "fullbase")
+    _run(spark, "container_metrics", "fullcap", max_containers_per_run=1)
+
+    assert _container_ids(spark, "fullbase") == [1, 2, 3]
+    assert _container_ids(spark, "fullcap") == [1, 2, 3]
+    for table in ("histogram_fact", "stats_aggregator_fact", "measurement_dimension"):
+        capped = spark.read.table(f"spark_catalog.gold.fullcap_{table}")
+        uncapped = spark.read.table(f"spark_catalog.gold.fullbase_{table}")
+        assert _rows_without_meta(capped) == _rows_without_meta(
+            uncapped
+        ), f"{table}: chunked full-mode solve must match the uncapped solve"
+
+
+def test_changed_entity_capped_defers_beyond_cap_new_and_matches_uncapped(spark):
+    """A changed definition recomputes historical + capped-new; new-beyond-cap deferred."""
+    # Seed gold with container 1 under definition D1.
+    _run(spark, "container_metrics_inc_1", "chg")
+    assert _container_ids(spark, "chg") == [1]
+
+    # Change the definition (D2) and add containers 2,3; incremental, cap=1.
+    # Run 1: changed entity computed for historical {1} + capped new {2}; 3 deferred.
+    _run(
+        spark,
+        "container_metrics",
+        "chg",
+        max_containers_per_run=1,
+        add_aggs=add_aggs_to_report_changed_bins,
+    )
+    assert _container_ids(spark, "chg") == [1, 2], "beyond-cap new container 3 must be deferred"
+    assert _hist_container_ids(spark, "chg") == {1, 2}, "no facts for the deferred container"
+
+    # Run 2 advances to container 3 (definition now unchanged -> unchanged path).
+    _run(
+        spark,
+        "container_metrics",
+        "chg",
+        max_containers_per_run=1,
+        add_aggs=add_aggs_to_report_changed_bins,
+    )
+    assert _container_ids(spark, "chg") == [1, 2, 3]
+
+    # Uncapped reference: D1 on container 1, then D2 over all containers in one run.
+    _run(spark, "container_metrics_inc_1", "chgbase")
+    _run(spark, "container_metrics", "chgbase", add_aggs=add_aggs_to_report_changed_bins)
+
+    for table in ("histogram_fact", "stats_aggregator_fact"):
+        capped = spark.read.table(f"spark_catalog.gold.chg_{table}")
+        uncapped = spark.read.table(f"spark_catalog.gold.chgbase_{table}")
+        assert _rows_without_meta(capped) == _rows_without_meta(
+            uncapped
+        ), f"{table}: capped changed-entity iteration must match the uncapped run"

--- a/tests/impulse_reporting/unit/config/config_parser_test.py
+++ b/tests/impulse_reporting/unit/config/config_parser_test.py
@@ -145,6 +145,30 @@ def test_impulse_config_drop_implausible_data_enabled():
     assert config.query_engine.drop_implausible_data is True
 
 
+def test_impulse_config_max_containers_per_run_defaults_to_none():
+    """The container cap is off by default (no cap => current behavior)."""
+    config = ImpulseConfig.model_validate(impulse_config_JSON.copy())
+    assert config.query_engine.max_containers_per_run is None
+
+
+def test_impulse_config_max_containers_per_run_parsed():
+    config_json = {
+        **impulse_config_JSON,
+        "query_engine": {"solver": "KeyValueStoreSolver", "max_containers_per_run": 50},
+    }
+    config = ImpulseConfig.model_validate(config_json)
+    assert config.query_engine.max_containers_per_run == 50
+
+
+def test_impulse_config_max_containers_per_run_rejects_non_positive():
+    config_json = {
+        **impulse_config_JSON,
+        "query_engine": {"solver": "KeyValueStoreSolver", "max_containers_per_run": 0},
+    }
+    with pytest.raises(ValidationError, match="max_containers_per_run must be >= 1"):
+        ImpulseConfig.model_validate(config_json)
+
+
 # ---------------------------------------------------------------------------
 # Source.poi_channels_uri — must survive parsing AND reach the MeasurementDB.
 # Regression: the field was missing from the Source model, so pydantic silently

--- a/tests/impulse_reporting/unit/incremental/container_detector_test.py
+++ b/tests/impulse_reporting/unit/incremental/container_detector_test.py
@@ -171,18 +171,19 @@ def test_detects_both_new_and_updated_containers(spark, cleanup_test_tables):
     assert sorted(result_ids) == [1, 3]
 
 
-def test_detect_updated_containers_excludes_new(spark, cleanup_test_tables):
-    """detect_updated_containers returns updated containers but NOT new ones."""
+def test_updated_within_excludes_new(spark, cleanup_test_tables):
+    """updated_within keeps candidates already in gold (updated) and drops new ones."""
     detector = ContainerUpsertDetector(spark)
     newer_timestamp = BASE_TIMESTAMP + timedelta(hours=1)
 
-    # Container 1: updated (newer); 2: unchanged; 3: new (absent from gold).
-    silver_data = [
-        Row(container_id=1, file_name="file1.dat", last_modified=newer_timestamp),
-        Row(container_id=2, file_name="file2.dat", last_modified=BASE_TIMESTAMP),
-        Row(container_id=3, file_name="file3.dat", last_modified=newer_timestamp),
-    ]
-    silver_df = spark.createDataFrame(silver_data, schema=SILVER_CONTAINER_SCHEMA)
+    # Candidates are the upserted set: container 1 (updated, in gold) and 3 (new, absent).
+    candidates = spark.createDataFrame(
+        [
+            Row(container_id=1, file_name="file1.dat", last_modified=newer_timestamp),
+            Row(container_id=3, file_name="file3.dat", last_modified=newer_timestamp),
+        ],
+        schema=SILVER_CONTAINER_SCHEMA,
+    )
 
     gold_data = [
         Row(container_id=1, last_modified=BASE_TIMESTAMP, _created_at=BASE_TIMESTAMP),
@@ -193,26 +194,25 @@ def test_detect_updated_containers_excludes_new(spark, cleanup_test_tables):
         "spark_catalog.gold.test_measurement_dimension"
     )
 
-    result = detector.detect_updated_containers(
-        silver_df, "spark_catalog.gold.test_measurement_dimension"
-    )
+    result = detector.updated_within(candidates, "spark_catalog.gold.test_measurement_dimension")
 
-    assert result is not None
-    # Only the updated container (1); the new one (3) is excluded.
+    # Only the updated container (1); the new one (3) is excluded. Silver schema preserved.
     assert [row.container_id for row in result.collect()] == [1]
+    assert result.columns == candidates.columns
 
 
-def test_detect_updated_containers_returns_none_when_gold_missing(spark):
-    """detect_updated_containers returns None when the gold table doesn't exist."""
+def test_updated_within_empty_when_gold_missing(spark):
+    """updated_within returns an empty DataFrame (not None) when the gold table is absent."""
     detector = ContainerUpsertDetector(spark)
-    silver_df = spark.createDataFrame(
+    candidates = spark.createDataFrame(
         [Row(container_id=1, file_name="test.dat", last_modified=datetime.now())],
         schema=SILVER_CONTAINER_SCHEMA,
     )
 
-    result = detector.detect_updated_containers(silver_df, "spark_catalog.gold.nonexistent_table")
+    result = detector.updated_within(candidates, "spark_catalog.gold.nonexistent_table")
 
-    assert result is None
+    assert result.count() == 0
+    assert result.columns == candidates.columns
 
 
 def test_returns_empty_dataframe_when_no_changes(spark, cleanup_test_tables):


### PR DESCRIPTION
## Summary

## What

Adds an optional `query_engine.max_containers_per_run` config that bounds how many
containers an incremental report run processes and commits, so a large or slow input
lands in the gold layer in smaller batches instead of one big run. Off by default (no
cap), preserving current behavior.

## How it works

- **Cap the batch.** In incremental mode the detected upserted container set is capped
  to N (ordered by `container_id`). Committed containers get a fresh
  `measurement_dimension` timestamp and drop out of the next detection, so runs advance
  through the population deterministically.
- **Scoped delete.** The incremental delete by source is derived from the capped set
  (via an inner join of the capped upserted containers with the gold measurement
  dimension), so a capped run never prunes rows for containers it did not reprocess.
- **Changed entities.** A changed definition still recomputes all historical containers,
  plus the capped new containers; new containers beyond the cap are deferred (they have
  no gold rows yet, so nothing is orphaned).
- **Bounded solve memory.** `solve_expressions_batched` and
  `solve_calculated_channels_batched` chunk the container set into batches of at most N
  using the existing temp table materialization, combining chunks with `unionByName`.
  Output is identical to an unchunked solve.
- **Draining `run()`.** `run()` loops determine plus persist until a run sees at most N
  remaining containers. After the first iteration all definition hashes are current, so
  later iterations recompute only unchanged entities over the next batch.

## Testing

Adds config unit tests and integration tests covering: cap honored per run, iteration to
completion matching an uncapped run, no pruning of out of batch updated containers,
full mode chunked solve matching uncapped, changed definition deferral and iteration, and
`run()` draining all batches in one call.

Closes #88

## Test Plan

- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Documentation updated (if applicable)

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] No new linter warnings introduced
